### PR TITLE
Rpm package v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ MKTEMP  = 	$(shell which mktemp)
 STRIP   = 	$(shell which strip)
 PANDOC  =       $(shell which pandoc)
 RPMBUILD =	$(shell which rpmbuild)
+GZIP	=	$(shell which gzip)
+SED	=	$(shell which sed)
+MKDIR	=	$(shell which mkdir)
 
 ifeq ($(PKGCONFIG),"")
 $(error "pkg-config not installed")
@@ -143,10 +146,13 @@ deb:
 
 rpm:
 	$(eval VERSION := $(subst -,_,$(shell $(GIT) describe --always --tags --dirty)))
-	$(RPMBUILD) -bb $(TARGET).spec \
-		--define "_topdir $(CURDIR)/rpmbuild" \
-		--define "_builddir $(CURDIR)" \
-		--define "pkg_version $(VERSION)"
+	$(MKDIR) -p rpmbuild/{BUILD,RPMS,SOURCES}
+	$(GIT) archive --prefix="$(TARGET)-$(VERSION)/" --format tar HEAD | \
+		$(GZIP) > rpmbuild/SOURCES/$(TARGET)-$(VERSION).tar.gz
+	$(SED) 's/__VERSION__/$(VERSION)/g' $(TARGET).spec > \
+		rpmbuild/SOURCES/$(TARGET).spec
+	$(RPMBUILD) -ba rpmbuild/SOURCES/$(TARGET).spec \
+		--define "_topdir $(CURDIR)/rpmbuild"
 
 .PHONY: all clean install help
 

--- a/mergerfs.spec
+++ b/mergerfs.spec
@@ -1,11 +1,12 @@
 Name:		mergerfs
-Version:	%{pkg_version}
+Version:	__VERSION__
 Release:	1%{?dist}
 Summary:	A FUSE union filesystem
 
 Group:		Applications/System
 License:	MIT
 URL:		https://github.com/trapexit/mergerfs
+Source:		mergerfs-%{version}.tar.gz
 
 BuildRequires:	gcc-c++
 BuildRequires:	libattr-devel
@@ -16,6 +17,9 @@ BuildRequires:	git
 BuildRequires:	pandoc
 
 Requires:	fuse-libs
+
+%prep
+%setup -q
 
 %description
 mergerfs is similar to mhddfs, unionfs, and aufs. Like mhddfs in that it too
@@ -33,5 +37,10 @@ make install DESTDIR=%{buildroot}
 %doc %{_mandir}/*
 
 %changelog
+* Mon Dec 29 2014 Joe Lawrence <joe.lawrence@stratus.com>
+- Tweak rpmbuild to archive current git HEAD into a tarball, then (re)build in
+  the rpmbuild directory -- more complicated but seemingly better suited to
+  generate source and debug rpms.
+
 * Fri Jun 20 2014 Joe Lawrence <joe.lawrence@stratus.com>
 - Initial rpm spec file.


### PR DESCRIPTION
I was going over some old files at the end of the year and noticed that I never sent these patches out.  This v2 branch was based off a later (most recent) master tip and tested on RHEL7.

The first rpm commit packages up files built from the source tree in their natural build locations.  When I went to extend the packaging to include a source rpm, I found that I needed a tarball of files with specific path prefix and a more precise spec file to drive the second generation build (ie, building from the generated source rpm).  So there are hokey sed and git archive tricks to this end.

I imagine Red Hat has some larger infrastructure behind their rpm generation, perhaps upstream source and packaging scripts in sub-repos, but I didn't think it was polite to rip up the entire mergerfs build just to add rpm.  RPM is horribly documented anyway and life is too short to learn any more of it this year.
