### PR TITLE
rework rename

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -133,7 +133,7 @@ namespace fs
           string path;
           struct stat st;
 
-          path = fs::path::make(paths[i],fusepath);
+          fs::path::make(paths[i],fusepath,path);
 
           rv  = ::lstat(path.c_str(),&st);
           if(rv == 0)
@@ -155,7 +155,7 @@ namespace fs
         string fullpath;
         struct stat st;
 
-        fullpath = fs::path::make(srcmounts[i],fusepath);
+        fs::path::make(srcmounts[i],fusepath,fullpath);
 
         rv = ::lstat(fullpath.c_str(),&st);
         if(rv == 0)
@@ -456,14 +456,14 @@ namespace fs
           return -1;
       }
 
-    frompath = fs::path::make(fromsrc,relative);
+    fs::path::make(fromsrc,relative,frompath);
     rv = ::stat(frompath.c_str(),&st);
     if(rv == -1)
       return -1;
     else if(!S_ISDIR(st.st_mode))
       return (errno = ENOTDIR,-1);
 
-    topath = fs::path::make(tosrc,relative);
+    fs::path::make(tosrc,relative,topath);
     rv = ::mkdir(topath.c_str(),st.st_mode);
     if(rv == -1)
       {

--- a/src/fs.hpp
+++ b/src/fs.hpp
@@ -61,6 +61,15 @@ namespace fs
 
     inline
     void
+    make(const string &base,
+         const string &suffix,
+         string       &output)
+    {
+      output = base + suffix;
+    }
+
+    inline
+    void
     append(string       &base,
            const string &suffix)
     {


### PR DESCRIPTION
Return EXDEV if directories of tragets differ. If the old and new path exist in the same directory first rename each old found by the policy and then unlink/rmdir any new on a drive which didn't rename. The unlink/rmdir will occur only if there were no rename errors. Any failures of unlink/rmdir are ignored. The last rename error is returned.