### PR TITLE
allow build WITHOUT_XATTR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 # Debian files
 debian/files
 debian/changelog
+
+# ignore build artifacts
+obj/
+rpmbuild/
+src/version.hpp

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ rpm-clean:
 rpm: tarball
 	$(eval VERSION := $(shell $(GIT) describe --always --tags --dirty))
 	$(eval VERSION := $(subst -,_,$(VERSION)))
-	$(MKDIR) -p rpmbuild/{BUILD,RPMS,SOURCES}
+	$(MKDIR) -p rpmbuild/BUILD rpmbuild/RPMS,SOURCES rpmbuild/SOURCES
 	$(SED) 's/__VERSION__/$(VERSION)/g' $(TARGET).spec > \
 		rpmbuild/SOURCES/$(TARGET).spec
 	cp -ar $(TARGET)-$(VERSION).tar.gz rpmbuild/SOURCES

--- a/src/fs_xattr.cpp
+++ b/src/fs_xattr.cpp
@@ -24,7 +24,10 @@
 
 #include <stdlib.h>
 #include <sys/types.h>
+#ifndef WITHOUT_XATTR
 #include <attr/xattr.h>
+#endif
+#include <errno.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>

--- a/src/getxattr.cpp
+++ b/src/getxattr.cpp
@@ -62,7 +62,7 @@ _lgetxattr(const string &path,
 
   return ((rv == -1) ? -errno : rv);
 #else
-  return -ENOSUP;
+  return -ENOTSUP;
 #endif
 }
 


### PR DESCRIPTION
I accidentally compiled without `libattr1-dev`, and the build failed.  These small corrections are needed to have a successful build.