### PR TITLE
clearly separate usage of statvfs from stat for file existance

### DIFF
--- a/src/fs.hpp
+++ b/src/fs.hpp
@@ -28,19 +28,19 @@ namespace fs
 
   bool exists(const string &path,
               struct stat  &st);
-  bool exists(const string   &path,
-              struct statvfs &st);
   bool exists(const string &path);
-  bool exists(const string &path,
-              bool         &readonly,
-              size_t       &spaceavail);
 
-  bool exists_on_rw_fs(const string   &path,
-                       struct statvfs &st);
-  bool exists_on_rw_fs(const string &path);
+  bool statvfs(const string   &path,
+               struct statvfs &st);
 
-  bool exists_on_rw_fs_with_at_least(const string &path,
-                                     const size_t minfreespace);
+  bool info(const string &path,
+            bool         &readonly,
+            size_t       &spaceavail);
+
+  bool readonly(const string &path);
+
+  bool spaceavail(const string &path,
+                  size_t       &spaceavail);
 
   void findallfiles(const vector<string> &srcmounts,
                     const char           *fusepath,
@@ -61,13 +61,6 @@ namespace fs
   int mfs(const vector<string> &srcs,
           const size_t          minfreespace,
           string               &path);
-
-  bool available(const string &path,
-                 const bool    needswritablefs);
-
-  bool available(const string   &path,
-                 const bool      needswritablefs,
-                 struct statvfs &st);
 };
 
 #endif // __FS_HPP__

--- a/src/policy_eplfs.cpp
+++ b/src/policy_eplfs.cpp
@@ -15,73 +15,114 @@
 */
 
 #include <errno.h>
-#include <sys/statvfs.h>
 
+#include <limits>
 #include <string>
 #include <vector>
 
 #include "fs.hpp"
 #include "fs_path.hpp"
 #include "policy.hpp"
-#include "statvfs_util.hpp"
 
 using std::string;
 using std::vector;
 using std::size_t;
-using mergerfs::Policy;
 using mergerfs::Category;
 
 static
-void
-_calc_lfs(const struct statvfs  &st,
-          const string          *basepath,
-          const size_t           minfreespace,
-          fsblkcnt_t            &lfs,
-          const string         *&lfsbasepath)
-{
-  fsblkcnt_t spaceavail;
-
-  spaceavail = StatVFS::spaceavail(st);
-  if((spaceavail > minfreespace) && (spaceavail < lfs))
-    {
-      lfs         = spaceavail;
-      lfsbasepath = basepath;
-    }
-}
-
-static
 int
-_eplfs(const vector<string>  &basepaths,
-       const char            *fusepath,
-       const size_t           minfreespace,
-       const bool             needswritablefs,
-       vector<const string*> &paths)
+_eplfs_create(const vector<string>  &basepaths,
+              const char            *fusepath,
+              const size_t           minfreespace,
+              vector<const string*> &paths)
 {
   string fullpath;
-  struct statvfs st;
-  fsblkcnt_t eplfs;
+  size_t eplfs;
   const string *eplfsbasepath;
 
-  eplfs = -1;
+  eplfs = std::numeric_limits<size_t>::max();
   eplfsbasepath = NULL;
   for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
     {
+      bool readonly;
+      size_t spaceavail;
       const string *basepath = &basepaths[i];
 
       fs::path::make(basepath,fusepath,fullpath);
 
-      if(!fs::available(fullpath,needswritablefs,st))
+      if(!fs::exists(fullpath))
+        continue;
+      if(!fs::info(*basepath,readonly,spaceavail))
+        continue;
+      if(readonly)
+        continue;
+      if(spaceavail < minfreespace)
+        continue;
+      if(spaceavail > eplfs)
         continue;
 
-      _calc_lfs(st,basepath,minfreespace,eplfs,eplfsbasepath);
+      eplfs = spaceavail;
+      eplfsbasepath = basepath;
     }
 
   if(eplfsbasepath == NULL)
-    return (errno=ENOENT,POLICY_FAIL);
+    return POLICY_FAIL_ENOENT;
 
   paths.push_back(eplfsbasepath);
 
   return POLICY_SUCCESS;
+}
+
+static
+int
+_eplfs_other(const vector<string>  &basepaths,
+             const char            *fusepath,
+             vector<const string*> &paths)
+{
+  string fullpath;
+  size_t eplfs;
+  const string *eplfsbasepath;
+
+  eplfs = std::numeric_limits<size_t>::max();
+  eplfsbasepath = NULL;
+  for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
+    {
+      size_t spaceavail;
+      const string *basepath = &basepaths[i];
+
+      fs::path::make(basepath,fusepath,fullpath);
+
+      if(!fs::exists(fullpath))
+        continue;
+      if(!fs::spaceavail(*basepath,spaceavail))
+        continue;
+      if(spaceavail > eplfs)
+        continue;
+
+      eplfs = spaceavail;
+      eplfsbasepath = basepath;
+    }
+
+  if(eplfsbasepath == NULL)
+    return POLICY_FAIL_ENOENT;
+
+  paths.push_back(eplfsbasepath);
+
+  return POLICY_SUCCESS;
+}
+
+static
+int
+_eplfs(const Category::Enum::Type type,
+       const vector<string>       &basepaths,
+       const char                 *fusepath,
+       const size_t                minfreespace,
+       vector<const string*>      &paths)
+{
+  if(type == Category::Enum::create)
+    return _eplfs_create(basepaths,fusepath,minfreespace,paths);
+
+  return _eplfs_other(basepaths,fusepath,paths);
 }
 
 namespace mergerfs
@@ -94,12 +135,8 @@ namespace mergerfs
                       vector<const string*>      &paths)
   {
     int rv;
-    const bool needswritablefs =
-      (type == Category::Enum::create);
-    const size_t minfs =
-      ((type == Category::Enum::create) ? minfreespace : 0);
 
-    rv = _eplfs(basepaths,fusepath,minfs,needswritablefs,paths);
+    rv = _eplfs(type,basepaths,fusepath,minfreespace,paths);
     if(POLICY_FAILED(rv))
       rv = Policy::Func::lfs(type,basepaths,fusepath,minfreespace,paths);
 

--- a/src/policy_erofs.cpp
+++ b/src/policy_erofs.cpp
@@ -33,6 +33,6 @@ namespace mergerfs
                       const size_t                minfreespace,
                       vector<const string*>      &paths)
   {
-    return (errno=EROFS,POLICY_FAIL);
+    return POLICY_FAIL_ERRNO(EROFS);
   }
 }

--- a/src/policy_invalid.cpp
+++ b/src/policy_invalid.cpp
@@ -34,6 +34,6 @@ namespace mergerfs
                         const size_t                minfreespace,
                         vector<const string*>      &paths)
   {
-    return (errno=EINVAL,POLICY_FAIL);
+    return POLICY_FAIL_ERRNO(EINVAL);
   }
 }

--- a/src/policy_lfs.cpp
+++ b/src/policy_lfs.cpp
@@ -15,74 +15,111 @@
 */
 
 #include <errno.h>
-#include <sys/statvfs.h>
 
+#include <limits>
 #include <string>
 #include <vector>
 
 #include "fs.hpp"
 #include "fs_path.hpp"
 #include "policy.hpp"
-#include "statvfs_util.hpp"
 
 using std::string;
 using std::vector;
 using std::size_t;
-using mergerfs::Policy;
 using mergerfs::Category;
 
 static
-void
-_calc_lfs(const struct statvfs  &st,
-          const string          *basepath,
-          const size_t           minfreespace,
-          fsblkcnt_t            &lfs,
-          const string         *&lfsbasepath)
-{
-  fsblkcnt_t spaceavail;
-
-  spaceavail = StatVFS::spaceavail(st);
-  if((spaceavail > minfreespace) && (spaceavail < lfs))
-    {
-      lfs         = spaceavail;
-      lfsbasepath = basepath;
-    }
-}
-
-static
 int
-_lfs(const vector<string>  &basepaths,
-     const char            *fusepath,
-     const size_t           minfreespace,
-     const bool             needswritablefs,
-     vector<const string*> &paths)
+_lfs_create(const vector<string>  &basepaths,
+            const size_t           minfreespace,
+            vector<const string*> &paths)
 {
   string fullpath;
-  struct statvfs st;
-  fsblkcnt_t lfs;
+  size_t lfs;
   const string *lfsbasepath;
 
-  lfs = -1;
+  lfs = std::numeric_limits<size_t>::max();
   lfsbasepath = NULL;
   for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
     {
+      bool readonly;
+      size_t spaceavail;
       const string *basepath = &basepaths[i];
 
-      fs::path::make(basepath,fusepath,fullpath);
-
-      if(!fs::available(fullpath,needswritablefs,st))
+      if(!fs::info(*basepath,readonly,spaceavail))
+        continue;
+      if(readonly)
+        continue;
+      if(spaceavail < minfreespace)
+        continue;
+      if(spaceavail > lfs)
         continue;
 
-      _calc_lfs(st,basepath,minfreespace,lfs,lfsbasepath);
+      lfs = spaceavail;
+      lfsbasepath = basepath;
     }
 
   if(lfsbasepath == NULL)
-    return (errno=ENOENT,POLICY_FAIL);
+    return POLICY_FAIL_ENOENT;
 
   paths.push_back(lfsbasepath);
 
   return POLICY_SUCCESS;
 }
+
+static
+int
+_lfs_other(const vector<string>  &basepaths,
+           const char            *fusepath,
+           vector<const string*> &paths)
+{
+  string fullpath;
+  size_t lfs;
+  const string *lfsbasepath;
+
+  lfs = std::numeric_limits<size_t>::max();
+  lfsbasepath = NULL;
+  for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
+    {
+      size_t spaceavail;
+      const string *basepath = &basepaths[i];
+
+      fs::path::make(basepath,fusepath,fullpath);
+
+      if(!fs::exists(fullpath))
+        continue;
+      if(!fs::spaceavail(*basepath,spaceavail))
+        continue;
+      if(spaceavail > lfs)
+        continue;
+
+      lfs = spaceavail;
+      lfsbasepath = basepath;
+    }
+
+  if(lfsbasepath == NULL)
+    return POLICY_FAIL_ENOENT;
+
+  paths.push_back(lfsbasepath);
+
+  return POLICY_SUCCESS;
+}
+
+static
+int
+_lfs(const Category::Enum::Type  type,
+     const vector<string>       &basepaths,
+     const char                 *fusepath,
+     const size_t                minfreespace,
+     vector<const string*>      &paths)
+{
+  if(type == Category::Enum::create)
+    return _lfs_create(basepaths,minfreespace,paths);
+
+  return _lfs_other(basepaths,fusepath,paths);
+}
+
 
 namespace mergerfs
 {
@@ -94,12 +131,8 @@ namespace mergerfs
                     vector<const string*>      &paths)
   {
     int rv;
-    const char *fp =
-      ((type == Category::Enum::create) ? "" : fusepath);
-    const bool needswritablefs =
-      (type == Category::Enum::create);
 
-    rv = _lfs(basepaths,fp,minfreespace,needswritablefs,paths);
+    rv = _lfs(type,basepaths,fusepath,minfreespace,paths);
     if(POLICY_FAILED(rv))
       rv = Policy::Func::mfs(type,basepaths,fusepath,minfreespace,paths);
 

--- a/src/policy_mfs.cpp
+++ b/src/policy_mfs.cpp
@@ -15,7 +15,6 @@
 */
 
 #include <errno.h>
-#include <sys/statvfs.h>
 
 #include <string>
 #include <vector>
@@ -23,61 +22,97 @@
 #include "fs.hpp"
 #include "fs_path.hpp"
 #include "policy.hpp"
-#include "statvfs_util.hpp"
 
 using std::string;
 using std::vector;
 using std::size_t;
-
-static
-void
-_calc_mfs(const struct statvfs  &st,
-          const string          *basepath,
-          fsblkcnt_t            &mfs,
-          const string         *&mfsbasepath)
-{
-  fsblkcnt_t spaceavail;
-
-  spaceavail = StatVFS::spaceavail(st);
-  if(spaceavail > mfs)
-    {
-      mfs         = spaceavail;
-      mfsbasepath = basepath;
-    }
-}
+using mergerfs::Category;
 
 static
 int
-_mfs(const vector<string>  &basepaths,
-     const char            *fusepath,
-     const bool             needswritablefs,
-     vector<const string*> &paths)
+_mfs_create(const vector<string>  &basepaths,
+            vector<const string*> &paths)
 {
   string fullpath;
-  struct statvfs st;
-  fsblkcnt_t mfs;
+  size_t mfs;
   const string *mfsbasepath;
 
   mfs = 0;
   mfsbasepath = NULL;
   for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
     {
+      bool readonly;
+      size_t spaceavail;
       const string *basepath = &basepaths[i];
 
-      fs::path::make(basepath,fusepath,fullpath);
-
-      if(!fs::available(fullpath,needswritablefs,st))
+      if(!fs::info(*basepath,readonly,spaceavail))
+        continue;
+      if(readonly)
+        continue;
+      if(spaceavail < mfs)
         continue;
 
-      _calc_mfs(st,basepath,mfs,mfsbasepath);
+      mfs = spaceavail;
+      mfsbasepath = basepath;
     }
 
   if(mfsbasepath == NULL)
-    return (errno=ENOENT,POLICY_FAIL);
+    return POLICY_FAIL_ENOENT;
 
   paths.push_back(mfsbasepath);
 
   return POLICY_SUCCESS;
+}
+
+static
+int
+_mfs_other(const vector<string>  &basepaths,
+           const char            *fusepath,
+           vector<const string*> &paths)
+{
+  string fullpath;
+  size_t mfs;
+  const string *mfsbasepath;
+
+  mfs = 0;
+  mfsbasepath = NULL;
+  for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
+    {
+      size_t spaceavail;
+      const string *basepath = &basepaths[i];
+
+      fs::path::make(basepath,fusepath,fullpath);
+
+      if(!fs::exists(fullpath))
+        continue;
+      if(!fs::spaceavail(*basepath,spaceavail))
+        continue;
+      if(spaceavail < mfs)
+        continue;
+
+      mfs = spaceavail;
+      mfsbasepath = basepath;
+    }
+
+  if(mfsbasepath == NULL)
+    return POLICY_FAIL_ENOENT;
+
+  paths.push_back(mfsbasepath);
+
+  return POLICY_SUCCESS;
+}
+
+static
+int
+_mfs(const Category::Enum::Type  type,
+     const vector<string>       &basepaths,
+     const char                 *fusepath,
+     vector<const string*>      &paths)
+{
+  if(type == Category::Enum::create)
+    return _mfs_create(basepaths,paths);
+
+  return _mfs_other(basepaths,fusepath,paths);
 }
 
 namespace mergerfs
@@ -90,12 +125,8 @@ namespace mergerfs
                     vector<const string*>      &paths)
   {
     int rv;
-    const char *fp =
-      ((type == Category::Enum::create) ? "" : fusepath);
-    const bool needswritablefs =
-      (type == Category::Enum::create);
 
-    rv = _mfs(basepaths,fp,needswritablefs,paths);
+    rv = _mfs(type,basepaths,fusepath,paths);
     if(POLICY_FAILED(rv))
       rv = Policy::Func::ff(type,basepaths,fusepath,minfreespace,paths);
 

--- a/src/policy_newest.cpp
+++ b/src/policy_newest.cpp
@@ -38,13 +38,14 @@ _newest_create(const vector<string>  &basepaths,
 {
   time_t newest;
   string fullpath;
-  struct stat st;
   const string *newestbasepath;
 
   newest = std::numeric_limits<time_t>::min();
   newestbasepath = NULL;
   for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
     {
+
+      struct stat st;
       const string *basepath = &basepaths[i];
 
       fs::path::make(basepath,fusepath,fullpath);
@@ -53,10 +54,10 @@ _newest_create(const vector<string>  &basepaths,
         continue;
       if(st.st_mtime < newest)
         continue;
-      if(!fs::exists_on_rw_fs(fullpath))
+      if(fs::readonly(*basepath))
         continue;
 
-      newest         = st.st_mtime;
+      newest = st.st_mtime;
       newestbasepath = basepath;
     }
 
@@ -70,19 +71,19 @@ _newest_create(const vector<string>  &basepaths,
 
 static
 int
-_newest(const vector<string>  &basepaths,
-        const char            *fusepath,
-        vector<const string*> &paths)
+_newest_other(const vector<string>  &basepaths,
+              const char            *fusepath,
+              vector<const string*> &paths)
 {
   time_t newest;
   string fullpath;
-  struct stat st;
   const string *newestbasepath;
 
   newest = std::numeric_limits<time_t>::min();
   newestbasepath = NULL;
   for(size_t i = 0, ei = basepaths.size(); i != ei; i++)
     {
+      struct stat st;
       const string *basepath = &basepaths[i];
 
       fs::path::make(basepath,fusepath,fullpath);
@@ -92,7 +93,7 @@ _newest(const vector<string>  &basepaths,
       if(st.st_mtime < newest)
         continue;
 
-      newest         = st.st_mtime;
+      newest = st.st_mtime;
       newestbasepath = basepath;
     }
 
@@ -116,6 +117,6 @@ namespace mergerfs
     if(type == Category::Enum::create)
       return _newest_create(basepaths,fusepath,paths);
 
-    return _newest(basepaths,fusepath,paths);
+    return _newest_other(basepaths,fusepath,paths);
   }
 }


### PR DESCRIPTION
Used statvfs to also check for existance vs lstat. On dead symlinks
this resulted in ENOENT making certain functions fail.

closes #239