### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,14 +143,14 @@ distclean: clean
 install: install-base install-mount.mergerfs install-man
 
 install-base: $(TARGET)
-	$(INSTALL) -v -m 0755 -D "$(TARGET)" "$(INSTALLBINDIR)/$(TARGET)"
+	$(INSTALL) -v -m 0755 "$(TARGET)" "$(INSTALLBINDIR)/$(TARGET)"
 
 install-mount.mergerfs: mount.mergerfs
 	$(MKDIR) -p "$(INSTALLBINDIR)"
 	$(CP) -a "$<" "$(INSTALLBINDIR)/$<"
 
 install-man: $(MANPAGE)
-	$(INSTALL) -v -m 0644 -D "man/$(MANPAGE)" "$(INSTALLMAN1DIR)/$(MANPAGE)"
+	$(INSTALL) -v -m 0644 "man/$(MANPAGE)" "$(INSTALLMAN1DIR)/$(MANPAGE)"
 
 install-strip: install-base
 	$(STRIP) "$(INSTALLBINDIR)/$(TARGET)"

--- a/src/fs_base_fsync.hpp
+++ b/src/fs_base_fsync.hpp
@@ -33,6 +33,6 @@ namespace fs
   int
   fdatasync(const int fd)
   {
-    return ::fdatasync(fd);
+    return fs::fdatasync(fd);
   }
 }

--- a/src/fs_base_utimensat.hpp
+++ b/src/fs_base_utimensat.hpp
@@ -31,7 +31,7 @@ namespace fs
             const struct timespec  times[2],
             const int              flags)
   {
-    return ::utimensat(dirfd,path.c_str(),times,flags);
+    return fs::utimensat(dirfd,path.c_str(),times,flags);
   }
 
   static

--- a/src/fs_clonefile.cpp
+++ b/src/fs_clonefile.cpp
@@ -196,7 +196,7 @@ namespace fs
     if(fdin == -1)
       return -1;
 
-    const int    flags = O_CREAT|O_LARGEFILE|O_NOATIME|O_NOFOLLOW|O_TRUNC|O_WRONLY;
+    const int    flags = O_CREAT|O_NOFOLLOW|O_TRUNC|O_WRONLY;
     const mode_t mode  = S_IWUSR;
     fdout = fs::open(out,flags,mode);
     if(fdout == -1)

--- a/tools/cppfind
+++ b/tools/cppfind
@@ -2,6 +2,6 @@
 
 FUSE_CFLAGS="$(pkg-config --cflags fuse) -DFUSE_USE_VERSION=29"
 
-echo "#include <fuse.h>" | cpp ${FUSE_CFLAGS} | grep -q "${1}"
+echo "#include <fuse.h>" | cpp ${FUSE_CFLAGS} | grep "${1}" 2>&1 > /dev/null
 
 [ "$?" != "0" ]; echo $?


### PR DESCRIPTION
Out of the box mergerfs doesn't compile on FreeBSD. With this patch in place it does, but I am by no means suggesting these quick & dirty fixes are the right way to achieve this! A PR just seemed like a simple way to document where the problems are.
