### PR TITLE
return clonepath errors

### DIFF
--- a/src/create.cpp
+++ b/src/create.cpp
@@ -43,22 +43,24 @@ _create_core(const string &existingpath,
              const int     flags,
              uint64_t     &fh)
 {
-  int fd;
+  int rv;
   string fullpath;
 
   if(createpath != existingpath)
     {
       const ugid::SetRootGuard ugidGuard;
-      fs::clonepath(existingpath,createpath,fusedirpath);
+      rv = fs::clonepath(existingpath,createpath,fusedirpath);
+      if(rv == -1)
+        return -errno;
     }
 
   fs::path::make(&createpath,fusepath,fullpath);
 
-  fd = fs::open(fullpath,flags,mode);
-  if(fd == -1)
+  rv = fs::open(fullpath,flags,mode);
+  if(rv == -1)
     return -errno;
 
-  fh = reinterpret_cast<uint64_t>(new FileInfo(fd));
+  fh = reinterpret_cast<uint64_t>(new FileInfo(rv));
 
   return 0;
 }

--- a/src/mkdir.cpp
+++ b/src/mkdir.cpp
@@ -48,7 +48,9 @@ _mkdir_loop_core(const string &existingpath,
   if(createpath != existingpath)
     {
       const ugid::SetRootGuard ugidGuard;
-      fs::clonepath(existingpath,createpath,fusedirpath);
+      rv = fs::clonepath(existingpath,createpath,fusedirpath);
+      if(rv == -1)
+        return errno;
     }
 
   fs::path::make(&createpath,fusepath,fullpath);

--- a/src/mknod.cpp
+++ b/src/mknod.cpp
@@ -48,7 +48,9 @@ _mknod_loop_core(const string &existingpath,
   if(createpath != existingpath)
     {
       const ugid::SetRootGuard ugidGuard;
-      fs::clonepath(existingpath,createpath,fusedirpath);
+      rv = fs::clonepath(existingpath,createpath,fusedirpath);
+      if(rv == -1)
+        return -1;
     }
 
   fs::path::make(&createpath,fusepath,fullpath);

--- a/src/rename.cpp
+++ b/src/rename.cpp
@@ -58,6 +58,27 @@ _remove(const vector<string> &toremove)
 }
 
 static
+int
+_rename(const std::string &oldbasepath,
+        const std::string &oldfullpath,
+        const std::string &newbasepath,
+        const std::string &newfusedirpath,
+        const std::string &newfullpath)
+{
+  int rv;
+
+  if(oldbasepath != newbasepath)
+    {
+      const ugid::SetRootGuard guard;
+      rv = fs::clonepath(newbasepath,oldbasepath,newfusedirpath.c_str());
+      if(rv == -1)
+        return -1;
+    }
+
+  return fs::rename(oldfullpath,newfullpath);
+}
+
+static
 void
 _rename_create_path_core(const vector<const string*> &oldbasepaths,
                          const string                &oldbasepath,
@@ -78,15 +99,10 @@ _rename_create_path_core(const vector<const string*> &oldbasepaths,
   ismember = member(oldbasepaths,oldbasepath);
   if(ismember)
     {
-      if(oldbasepath != newbasepath)
-        {
-          const ugid::SetRootGuard ugidGuard;
-          fs::clonepath(newbasepath,oldbasepath,newfusedirpath.c_str());
-        }
-
       fs::path::make(&oldbasepath,oldfusepath,oldfullpath);
 
-      rv = fs::rename(oldfullpath,newfullpath);
+      rv = _rename(oldbasepath,oldfullpath,
+                   newbasepath,newfusedirpath,newfullpath);
       error = calc_error(rv,error,errno);
       if(RENAME_FAILED(rv))
         tounlink.push_back(oldfullpath);

--- a/src/symlink.cpp
+++ b/src/symlink.cpp
@@ -49,7 +49,9 @@ _symlink_loop_core(const string &existingpath,
   if(newbasepath != existingpath)
     {
       const ugid::SetRootGuard ugidGuard;
-      fs::clonepath(existingpath,newbasepath,newdirpath);
+      rv = fs::clonepath(existingpath,newbasepath,newdirpath);
+      if(rv == -1)
+        return -1;
     }
 
   fs::path::make(&newbasepath,newpath,fullnewpath);


### PR DESCRIPTION
currently the error is ignored and it was expected the primary call would
fail. problem is it returns confusing errors as a result. (eg ENOENT vs EPERM)