### PR TITLE
support setting of inodes (using use_ino option)

### DIFF
--- a/man/mergerfs.1
+++ b/man/mergerfs.1
@@ -1,5 +1,5 @@
 .\"t
-.TH "mergerfs" "1" "2016\-10\-13" "mergerfs user manual" ""
+.TH "mergerfs" "1" "2016\-12\-14" "mergerfs user manual" ""
 .SH NAME
 .PP
 mergerfs \- another (FUSE based) union filesystem
@@ -73,6 +73,11 @@ Example: \f[B]category.create=mfs\f[]
 \f[B]mount\f[], \f[B]df\f[], etc.
 Defaults to a list of the source paths concatenated together with the
 longest common prefix removed.
+.IP \[bu] 2
+\f[B]use_ino\f[]: causes mergerfs to supply file/directory inodes rather
+than libfuse.
+While not a default it is generally recommended it be enabled so that
+hard linked files share the same inode value.
 .PP
 \f[B]NOTE:\f[] Options are evaluated in the order listed so if the
 options are \f[B]func.rmdir=rand,category.action=ff\f[] the
@@ -959,6 +964,16 @@ drive and receive ENOSPC errors.
 That is expected with those settings.
 If you don\[aq]t want that: enable \f[B]moveonenospc\f[] and don\[aq]t
 use a path preserving policy.
+.SS How are inodes calculated?
+.PP
+mergerfs\-inode = (original\-inode | (device\-id << 32))
+.PP
+While \f[C]ino_t\f[] is 64 bits few filesystems use more than 32.
+Similarly, while \f[C]dev_t\f[] is also 64 bits it was traditionally 16
+bits.
+Bitwise or\[aq]ing them together should work most of the time.
+Should it cause a problem in the future the values could be hashed
+instead.
 .SS It\[aq]s mentioned that there are some security issues with mhddfs.
 What are they? How does mergerfs address them?
 .PP

--- a/src/fs_inode.hpp
+++ b/src/fs_inode.hpp
@@ -1,4 +1,6 @@
 /*
+  ISC License
+
   Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
@@ -14,41 +16,27 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#include <fuse.h>
+#ifndef __FS_INODE_HPP__
+#define __FS_INODE_HPP__
 
-#include "errno.hpp"
-#include "fileinfo.hpp"
-#include "fs_base_stat.hpp"
-#include "fs_inode.hpp"
+#include <sys/stat.h>
 
-static
-int
-_fgetattr(const int    fd,
-          struct stat &st)
+namespace fs
 {
-  int rv;
-
-  rv = fs::fstat(fd,st);
-  if(rv == -1)
-    return -errno;
-
-  fs::inode::recompute(st);
-
-  return 0;
-}
-
-namespace mergerfs
-{
-  namespace fuse
+  namespace inode
   {
-    int
-    fgetattr(const char     *fusepath,
-             struct stat    *st,
-             fuse_file_info *ffi)
-    {
-      FileInfo *fi = reinterpret_cast<FileInfo*>(ffi->fh);
+    enum
+      {
+        MAGIC = 0x7472617065786974
+      };
 
-      return _fgetattr(fi->fd,*st);
+    inline
+    void
+    recompute(struct stat &st)
+    {
+      st.st_ino |= (st.st_dev << 32);
     }
   }
 }
+
+#endif

--- a/src/readdir.cpp
+++ b/src/readdir.cpp
@@ -27,6 +27,8 @@
 #include "fs_base_closedir.hpp"
 #include "fs_base_opendir.hpp"
 #include "fs_base_readdir.hpp"
+#include "fs_base_stat.hpp"
+#include "fs_inode.hpp"
 #include "fs_path.hpp"
 #include "readdir.hpp"
 #include "rwlock.hpp"
@@ -50,6 +52,7 @@ _readdir(const vector<string>  &srcmounts,
   struct stat st = {0};
   StrSet names;
 
+  st.st_ino = fs::inode::MAGIC;
   for(size_t i = 0, ei = srcmounts.size(); i != ei; i++)
     {
       DIR *dh;


### PR DESCRIPTION
creates a 64bit inode value from the underlying device value + original inode

final_ino = orig_ino | (dev << 32)

not perfect but given few filesystems use 64bit inodes nor is st_dev more than 16bit usually it should be fine