### PR TITLE
Makefile: don't force -g, respect CPPFLAGS, don't require `which`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,31 +12,38 @@
 #  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 #  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-GIT 	  = 	$(shell which git)
-TAR 	  = 	$(shell which tar)
-MKDIR     = 	$(shell which mkdir)
-TOUCH 	  = 	$(shell which touch)
-CP        = 	$(shell which cp)
-RM 	  = 	$(shell which rm)
-LN        =     $(shell which ln)
-FIND 	  = 	$(shell which find)
-INSTALL   = 	$(shell which install)
-MKTEMP    = 	$(shell which mktemp)
-STRIP     = 	$(shell which strip)
-PANDOC    =	$(shell which pandoc)
-SED       =     $(shell which sed)
-GZIP      =     $(shell which gzip)
-RPMBUILD  =     $(shell which rpmbuild)
-GIT2DEBCL =     ./tools/git2debcl
-PKGCONFIG =     pkg-config
+GIT       = git
+TAR       = tar
+MKDIR     = mkdir
+TOUCH     = touch
+CP        = cp
+RM        = rm
+LN        = ln
+FIND      = find
+INSTALL   = install
+MKTEMP    = mktemp
+STRIP     = strip
+PANDOC    = pandoc
+SED       = sed
+GZIP      = gzip
+RPMBUILD  = rpmbuild
+GIT2DEBCL = ./tools/git2debcl
+PKGCONFIG = pkg-config
 
 GIT_REPO = 0
 ifneq ($(GIT),)
+ifneq ($(shell $(GIT) --version 2>/dev/null),)
 ifeq  ($(shell test -e .git; echo $$?),0)
 GIT_REPO = 1
 endif
 endif
+endif
 
+ifneq ($(PANDOC),)
+ifeq ($(shell $(PANDOC) --version 2>/dev/null),)
+PANDOC :=
+endif
+endif
 ifeq ($(PANDOC),)
 $(warning "pandoc does not appear available: manpage won't be buildable")
 endif

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,13 @@ endif
 
 UGID_USE_RWLOCK = 0
 
-OPTS 	    = -O2
+OPTS 	    = -g -O2
 SRC	    = $(wildcard src/*.cpp)
 OBJ         = $(SRC:src/%.cpp=obj/%.o)
 DEPS        = $(OBJ:obj/%.o=obj/%.d)
 TARGET      = mergerfs
 MANPAGE     = $(TARGET).1
-CFLAGS      = -g -Wall \
+CFLAGS      = -Wall \
 	      $(OPTS) \
 	      -Wno-unused-result \
               $(FUSE_CFLAGS) \
@@ -101,7 +101,7 @@ help:
 	@echo "make INTERNAL_FUSE=0   - to build program with external (system) libfuse rather than the bundled one ('-o threads=' option will be unavailable)"
 
 $(TARGET): version obj/obj-stamp $(FUSE_TARGET) $(OBJ)
-	$(CXX) $(CFLAGS) $(LDFLAGS) $(OBJ) -o $@ $(FUSE_LIBS) -ldl -pthread -lrt
+	$(CXX) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $(OBJ) -o $@ $(FUSE_LIBS) -ldl -pthread -lrt
 
 mount.mergerfs: $(TARGET)
 	$(LN) -fs "$<" "$@"
@@ -124,7 +124,7 @@ obj/obj-stamp:
 	$(TOUCH) $@
 
 obj/%.o: src/%.cpp
-	$(CXX) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 clean: rpm-clean libfuse_Makefile
 	$(RM) -f src/version.hpp


### PR DESCRIPTION
Please, find several Makefile fixes, which address some of the issues preventing [1] inclusion of mergerfs into Gentoo.

[1] https://github.com/gentoo/gentoo/pull/9544#issuecomment-414146058

@mgorny, please, feel free to take a look to make sure we're on the right track.