### PR TITLE
add FICLONE and copy_file_range to clonefile

### DIFF
--- a/src/fs_copy_file_range.cpp
+++ b/src/fs_copy_file_range.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,29 +16,8 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#pragma once
-
-#include <sys/ioctl.h>
-
-namespace fs
-{
-  static
-  inline
-  int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
-  {
-    return ::ioctl(fd_,request_,data_);
-  }
-
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
-  {
-    return ::ioctl(fd_,request_,int_);
-  }
-}
+#ifdef __linux__
+# include "fs_copy_file_range_linux.icpp"
+#else
+# include "fs_copy_file_range_unsupported.icpp"
+#endif

--- a/src/fs_copy_file_range.hpp
+++ b/src/fs_copy_file_range.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -18,27 +18,23 @@
 
 #pragma once
 
-#include <sys/ioctl.h>
+#include <sys/types.h>
+
+#include <cstddef>
 
 namespace fs
 {
-  static
-  inline
-  int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
-  {
-    return ::ioctl(fd_,request_,data_);
-  }
+  ssize_t
+  copy_file_range(const int           fd_in_,
+                  loff_t             *off_in_,
+                  const int           fd_out_,
+                  loff_t             *off_out_,
+                  const size_t        len_,
+                  const unsigned int  flags_);
 
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
-  {
-    return ::ioctl(fd_,request_,int_);
-  }
+  ssize_t
+  copy_file_range(const int           fd_in_,
+                  const int           fd_out_,
+                  const size_t        len_,
+                  const unsigned int  flags_ = 0);
 }

--- a/src/fs_copy_file_range_linux.icpp
+++ b/src/fs_copy_file_range_linux.icpp
@@ -1,0 +1,87 @@
+/*
+  ISC License
+
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#define _GNU_SOURCE
+
+#include "errno.hpp"
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static
+loff_t
+copy_file_range_(int           fd_in_,
+                 loff_t       *off_in_,
+                 int           fd_out_,
+                 loff_t       *off_out_,
+                 size_t        len_,
+                 unsigned int  flags_)
+{
+#ifdef SYS_copy_file_range
+  return ::syscall(SYS_copy_file_range,
+                   fd_in_,
+                   off_in_,
+                   fd_out_,
+                   off_out_,
+                   len_,
+                   flags_);
+#else
+  return (errno=EOPNOTSUPP,-1);
+#endif
+}
+
+namespace fs
+{
+  ssize_t
+  copy_file_range(const int           fd_in_,
+                  loff_t             *off_in_,
+                  const int           fd_out_,
+                  loff_t             *off_out_,
+                  const size_t        len_,
+                  const unsigned int  flags_)
+  {
+    return ::copy_file_range_(fd_in_,
+                              off_in_,
+                              fd_out_,
+                              off_out_,
+                              len_,
+                              flags_);
+  }
+
+  ssize_t
+  copy_file_range(const int           fd_in_,
+                  const int           fd_out_,
+                  const size_t        len_,
+                  const unsigned int  flags_)
+  {
+    loff_t off_in;
+    loff_t off_out;
+
+    off_in  = 0;
+    off_out = 0;
+
+    return fs::copy_file_range(fd_in_,
+                               &off_in,
+                               fd_out_,
+                               &off_out,
+                               len_,
+                               flags_);
+  }
+}

--- a/src/fs_copy_file_range_unsupported.icpp
+++ b/src/fs_copy_file_range_unsupported.icpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,29 +16,27 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#pragma once
-
-#include <sys/ioctl.h>
+#include <cstddef>
 
 namespace fs
 {
-  static
-  inline
-  int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
+  ssize_t
+  copy_file_range(const int           fd_in_,
+                  loff_t             *off_in_,
+                  const int           fd_out_,
+                  loff_t             *off_out_,
+                  const size_t        len_,
+                  const unsigned int  flags_)
   {
-    return ::ioctl(fd_,request_,data_);
+    return (errno=EOPNOTSUPP,-1);
   }
 
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
+  ssize_t
+  copy_file_range(const int           fd_in_,
+                  const int           fd_out_,
+                  const size_t        len_,
+                  const unsigned int  flags_)
   {
-    return ::ioctl(fd_,request_,int_);
+    return (errno=EOPNOTSUPP,-1);
   }
 }

--- a/src/fs_copyfile.cpp
+++ b/src/fs_copyfile.cpp
@@ -1,0 +1,110 @@
+/*
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "errno.hpp"
+#include "fs_base_stat.hpp"
+#include "fs_base_lseek.hpp"
+#include "fs_base_read.hpp"
+#include "fs_base_write.hpp"
+
+#include <vector>
+
+using std::vector;
+
+static
+int
+writen(const int     fd_,
+       const char   *buf_,
+       const size_t  count_)
+{
+  size_t nleft;
+  ssize_t nwritten;
+
+  nleft = count_;
+  do
+    {
+      nwritten = fs::write(fd_,buf_,nleft);
+      if((nwritten == -1) && (errno == EINTR))
+        continue;
+      if(nwritten == -1)
+        return -1;
+
+      nleft -= nwritten;
+      buf_  += nwritten;
+    }
+  while(nleft > 0);
+
+  return count_;
+}
+
+static
+int
+copyfile(const int    src_fd_,
+         const int    dst_fd_,
+         const size_t count_,
+         const size_t blocksize_)
+{
+  ssize_t nr;
+  ssize_t nw;
+  ssize_t bufsize;
+  size_t  totalwritten;
+  vector<char> buf;
+
+  bufsize = (blocksize_ * 16);
+  buf.resize(bufsize);
+
+  fs::lseek(src_fd_,0,SEEK_SET);
+
+  totalwritten = 0;
+  while(totalwritten < count_)
+    {
+      nr = fs::read(src_fd_,&buf[0],bufsize);
+      if(nr == 0)
+        return totalwritten;
+      if((nr == -1) && (errno == EINTR))
+        continue;
+      if(nr == -1)
+        return -1;
+
+      nw = writen(dst_fd_,&buf[0],nr);
+      if(nw == -1)
+        return -1;
+
+      totalwritten += nw;
+    }
+
+  return totalwritten;
+}
+
+namespace fs
+{
+  int
+  copyfile(const int src_fd_,
+           const int dst_fd_)
+  {
+    int rv;
+    struct stat st;
+
+    rv = fs::fstat(src_fd_,st);
+    if(rv == -1)
+      return rv;
+
+    return ::copyfile(src_fd_,
+                      dst_fd_,
+                      st.st_size,
+                      st.st_blksize);
+  }
+}

--- a/src/fs_copyfile.hpp
+++ b/src/fs_copyfile.hpp
@@ -1,6 +1,4 @@
 /*
-  ISC License
-
   Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
@@ -18,27 +16,9 @@
 
 #pragma once
 
-#include <sys/ioctl.h>
-
 namespace fs
 {
-  static
-  inline
   int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
-  {
-    return ::ioctl(fd_,request_,data_);
-  }
-
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
-  {
-    return ::ioctl(fd_,request_,int_);
-  }
+  copyfile(const int src_fd_,
+           const int dst_fd_);
 }

--- a/src/fs_ficlone.cpp
+++ b/src/fs_ficlone.cpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,29 +16,8 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#pragma once
-
-#include <sys/ioctl.h>
-
-namespace fs
-{
-  static
-  inline
-  int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
-  {
-    return ::ioctl(fd_,request_,data_);
-  }
-
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
-  {
-    return ::ioctl(fd_,request_,int_);
-  }
-}
+#ifdef __linux__
+# include "fs_ficlone_linux.icpp"
+#else
+# include "fs_ficlone_unsupported.icpp"
+#endif

--- a/src/fs_ficlone.hpp
+++ b/src/fs_ficlone.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -18,27 +18,9 @@
 
 #pragma once
 
-#include <sys/ioctl.h>
-
 namespace fs
 {
-  static
-  inline
   int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
-  {
-    return ::ioctl(fd_,request_,data_);
-  }
-
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
-  {
-    return ::ioctl(fd_,request_,int_);
-  }
+  ficlone(const int src_fd_,
+          const int dst_fd_);
 }

--- a/src/fs_ficlone_linux.icpp
+++ b/src/fs_ficlone_linux.icpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,29 +16,21 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#pragma once
+#include "errno.hpp"
+#include "fs_base_ioctl.hpp"
 
-#include <sys/ioctl.h>
+#include <linux/fs.h>
 
 namespace fs
 {
-  static
-  inline
   int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
+  ficlone(const int src_fd_,
+          const int dst_fd_)
   {
-    return ::ioctl(fd_,request_,data_);
-  }
-
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
-  {
-    return ::ioctl(fd_,request_,int_);
+#ifdef FICLONE
+    return fs::ioctl(dst_fd_,FICLONE,src_fd_);
+#else
+    return (errno=EOPNOTSUPP,-1);
+#endif
   }
 }

--- a/src/fs_ficlone_unsupported.icpp
+++ b/src/fs_ficlone_unsupported.icpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -16,29 +16,14 @@
   OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 */
 
-#pragma once
-
-#include <sys/ioctl.h>
+#include "errno.hpp"
 
 namespace fs
 {
-  static
-  inline
   int
-  ioctl(const int            fd_,
-        const unsigned long  request_,
-        void                *data_)
+  ficlone(const int src_fd_,
+          const int dst_fd_)
   {
-    return ::ioctl(fd_,request_,data_);
-  }
-
-  static
-  inline
-  int
-  ioctl(const int           fd_,
-        const unsigned long request_,
-        const int           int_)
-  {
-    return ::ioctl(fd_,request_,int_);
+    return (errno=EOPNOTSUPP,-1);
   }
 }


### PR DESCRIPTION
If available FICLONE and copy_file_range will be tried in addition to sendfile
when copying data between two files. The fallback is a tradition read/write
loop. On systems that support these it should improve performance.