### PR TITLE
optimize readdir file dedup

### DIFF
--- a/src/fasthash.cpp
+++ b/src/fasthash.cpp
@@ -1,0 +1,84 @@
+/* The MIT License
+
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#include "fasthash.h"
+
+// Compression function for Merkle-Damgard construction.
+// This function is generated using the framework provided.
+#define mix(h) ({                               \
+      (h) ^= (h) >> 23;                         \
+      (h) *= 0x2127599bf4325c37ULL;             \
+      (h) ^= (h) >> 47; })
+
+uint64_t
+fasthash64(const void *buf,
+           size_t      len,
+           uint64_t    seed)
+{
+  const uint64_t    m = 0x880355f21e6d1965ULL;
+  const uint64_t *pos = (const uint64_t *)buf;
+  const uint64_t *end = pos + (len / 8);
+  const unsigned char *pos2;
+  uint64_t h = seed ^ (len * m);
+  uint64_t v;
+
+  while (pos != end) {
+    v  = *pos++;
+    h ^= mix(v);
+    h *= m;
+  }
+
+  pos2 = (const unsigned char*)pos;
+  v = 0;
+
+  switch (len & 7) {
+  case 7: v ^= (uint64_t)pos2[6] << 48;
+  case 6: v ^= (uint64_t)pos2[5] << 40;
+  case 5: v ^= (uint64_t)pos2[4] << 32;
+  case 4: v ^= (uint64_t)pos2[3] << 24;
+  case 3: v ^= (uint64_t)pos2[2] << 16;
+  case 2: v ^= (uint64_t)pos2[1] << 8;
+  case 1: v ^= (uint64_t)pos2[0];
+    h ^= mix(v);
+    h *= m;
+  }
+
+  return mix(h);
+}
+
+uint32_t
+fasthash32(const void *buf,
+           size_t      len,
+           uint32_t    seed)
+{
+  // the following trick converts the 64-bit hashcode to Fermat
+  // residue, which shall retain information from both the higher
+  // and lower parts of hashcode.
+  uint64_t h;
+
+  h = fasthash64(buf, len, seed);
+
+  return (h - (h >> 32));
+}

--- a/src/fasthash.h
+++ b/src/fasthash.h
@@ -1,0 +1,56 @@
+/* The MIT License
+
+   Copyright (C) 2012 Zilong Tan (eric.zltan@gmail.com)
+
+   Permission is hereby granted, free of charge, to any person
+   obtaining a copy of this software and associated documentation
+   files (the "Software"), to deal in the Software without
+   restriction, including without limitation the rights to use, copy,
+   modify, merge, publish, distribute, sublicense, and/or sell copies
+   of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be
+   included in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+   SOFTWARE.
+*/
+
+#ifndef _FASTHASH_H
+#define _FASTHASH_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  /**
+   * fasthash32 - 32-bit implementation of fasthash
+   * @buf:  data buffer
+   * @len:  data size
+   * @seed: the seed
+   */
+  uint32_t fasthash32(const void *buf, size_t len, uint32_t seed);
+
+  /**
+   * fasthash64 - 64-bit implementation of fasthash
+   * @buf:  data buffer
+   * @len:  data size
+   * @seed: the seed
+   */
+  uint64_t fasthash64(const void *buf, size_t len, uint64_t seed);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/hashset.hpp
+++ b/src/hashset.hpp
@@ -1,7 +1,7 @@
 /*
   ISC License
 
-  Copyright (c) 2016, Antonio SJ Musumeci <trapexit@spawn.link>
+  Copyright (c) 2018, Antonio SJ Musumeci <trapexit@spawn.link>
 
   Permission to use, copy, modify, and/or distribute this software for any
   purpose with or without fee is hereby granted, provided that the above
@@ -19,44 +19,49 @@
 #pragma once
 
 #include "khash.h"
+#include "fasthash.h"
 
-#include <string.h>
+KHASH_SET_INIT_INT64(hashset);
 
-KHASH_SET_INIT_STR(strset);
-
-class StrSet
+class HashSet
 {
 public:
-  StrSet()
+  HashSet()
   {
-    _set = kh_init(strset);
+    _set = kh_init(hashset);
   }
 
-  ~StrSet()
+  ~HashSet()
   {
-    for(khint_t k = kh_begin(_set), ek = kh_end(_set); k != ek; k++)
-      if(kh_exist(_set,k))
-        ::free((char*)kh_key(_set,k));
-
-    kh_destroy(strset,_set);
+    kh_destroy(hashset,_set);
   }
 
   inline
   int
-  put(const char *str)
+  put(const char *str_)
   {
     int rv;
+    uint64_t h;
     khint_t key;
 
-    key = kh_put(strset,_set,str,&rv);
+    h = fasthash64(str_,strlen(str_),0x7472617065786974);
+
+    key = kh_put(hashset,_set,h,&rv);
     if(rv == 0)
       return 0;
 
-    kh_key(_set,key) = ::strdup(str);
+    kh_key(_set,key) = h;
 
     return rv;
   }
 
+  inline
+  int
+  size(void)
+  {
+    return kh_size(_set);
+  }
+
 private:
-  khash_t(strset) *_set;
+  khash_t(hashset) *_set;
 };

--- a/src/readdir.cpp
+++ b/src/readdir.cpp
@@ -19,7 +19,6 @@
 #include <fuse.h>
 
 #include <string>
-#include <set>
 #include <vector>
 
 #include "config.hpp"
@@ -33,9 +32,9 @@
 #include "fs_devid.hpp"
 #include "fs_inode.hpp"
 #include "fs_path.hpp"
+#include "hashset.hpp"
 #include "readdir.hpp"
 #include "rwlock.hpp"
-#include "strset.hpp"
 #include "ugid.hpp"
 
 using std::string;
@@ -50,7 +49,7 @@ _readdir(const Branches        &branches_,
          void                  *buf,
          const fuse_fill_dir_t  filler)
 {
-  StrSet names;
+  HashSet names;
   string basepath;
   struct stat st = {0};
 


### PR DESCRIPTION
Use fasthash64 to hash filenames to uint64_t and store in khash
set. Significantly reduces malloc/free'ing and memory usage.