### PR TITLE
change xattr setting notsup to nosys

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mergerfs does **not** support the copy-on-write (CoW) behavior found in **aufs**
 * **nullrw=true|false**: turns reads and writes into no-ops. The request will succeed but do nothing. Useful for benchmarking mergerfs. (default: false)
 * **ignorepponrename=true|false**: ignore path preserving on rename. Typically rename and link act differently depending on the policy of `create` (read below). Enabling this will cause rename and link to always use the non-path preserving behavior. This means files, when renamed or linked, will stay on the same drive. (default: false)
 * **security_capability=true|false**: If false return ENOATTR when xattr security.capability is queried. (default: true)
-* **xattr=passthrough|noattr|notsup**: Runtime control of xattrs. Default is to passthrough xattr requests. 'noattr' will short circuit as if nothing exists. 'notsup' will respond with ENOTSUP as if xattrs are not supported or disabled. (default: passthrough)
+* **xattr=passthrough|noattr|nosys**: Runtime control of xattrs. Default is to passthrough xattr requests. 'noattr' will short circuit as if nothing exists. 'nosys' will respond with ENOSYS as if xattrs are not supported or disabled. (default: passthrough)
 * **link_cow=true|false**: When enabled if a regular file is opened which has a link count > 1 it will copy the file to a temporary file and rename over the original. Breaking the link and providing a basic copy-on-write function similar to cow-shell. (default: false)
 * **statfs=base|full**: Controls how statfs works. 'base' means it will always use all branches in statfs calculations. 'full' is in effect path preserving and only includes drives where the path exists. (default: base)
 * **statfs_ignore=none|ro|nc**: 'ro' will cause statfs calculations to ignore available space for branches mounted or tagged as 'read only' or 'no create'. 'nc' will ignore available space for branches tagged as 'no create'. (default: none)
@@ -153,7 +153,7 @@ Runtime extended attribute support can be managed via the `xattr` option. By def
 
 `noattr` will cause mergerfs to short circuit all xattr calls and return ENOATTR where appropriate. mergerfs still gets all the requests but they will not be forwarded on to the underlying filesystems. The runtime control will still function in this mode.
 
-`notsup` will cause mergerfs to return ENOTSUP for any xattr call. The difference with `noattr` is that the kernel will cache this fact and itself short circuit future calls. This will be more efficient than `noattr` but will cause mergerfs' runtime control via the hidden file to stop working.
+`nosys` will cause mergerfs to return ENOSYS for any xattr call. The difference with `noattr` is that the kernel will cache this fact and itself short circuit future calls. This will be more efficient than `noattr` but will cause mergerfs' runtime control via the hidden file to stop working.
 
 # FUNCTIONS / POLICIES / CATEGORIES
 
@@ -765,7 +765,7 @@ and the kernel use internally (also called the "nodeid").
 
 Due to how NFS works and interacts with FUSE when not using `direct_io` its possible that a getxattr for `security.capability` will be issued prior to any write. This will usually result in a massive slowdown for writes. Using `direct_io` will keep this from happening (and generally good to enable unless you need the features it disables) but the `security_capability` option can also help by short circuiting the call and returning `ENOATTR`.
 
-You could also set `xattr` to `noattr` or `notsup` to short circuit or stop all xattr requests.
+You could also set `xattr` to `noattr` or `nosys` to short circuit or stop all xattr requests.
 
 #### What are these .fuse_hidden files?
 

--- a/man/mergerfs.1
+++ b/man/mergerfs.1
@@ -156,11 +156,11 @@ This means files, when renamed or linked, will stay on the same drive.
 xattr security.capability is queried.
 (default: true)
 .IP \[bu] 2
-\f[B]xattr=passthrough|noattr|notsup\f[]: Runtime control of xattrs.
+\f[B]xattr=passthrough|noattr|nosys\f[]: Runtime control of xattrs.
 Default is to passthrough xattr requests.
 \[aq]noattr\[aq] will short circuit as if nothing exists.
-\[aq]notsup\[aq] will respond with ENOTSUP as if xattrs are not
-supported or disabled.
+\[aq]nosys\[aq] will respond with ENOSYS as if xattrs are not supported
+or disabled.
 (default: passthrough)
 .IP \[bu] 2
 \f[B]link_cow=true|false\f[]: When enabled if a regular file is opened
@@ -356,8 +356,7 @@ mergerfs still gets all the requests but they will not be forwarded on
 to the underlying filesystems.
 The runtime control will still function in this mode.
 .PP
-\f[C]notsup\f[] will cause mergerfs to return ENOTSUP for any xattr
-call.
+\f[C]nosys\f[] will cause mergerfs to return ENOSYS for any xattr call.
 The difference with \f[C]noattr\f[] is that the kernel will cache this
 fact and itself short circuit future calls.
 This will be more efficient than \f[C]noattr\f[] but will cause
@@ -1629,7 +1628,7 @@ good to enable unless you need the features it disables) but the
 \f[C]security_capability\f[] option can also help by short circuiting
 the call and returning \f[C]ENOATTR\f[].
 .PP
-You could also set \f[C]xattr\f[] to \f[C]noattr\f[] or \f[C]notsup\f[]
+You could also set \f[C]xattr\f[] to \f[C]noattr\f[] or \f[C]nosys\f[]
 to short circuit or stop all xattr requests.
 .SS What are these .fuse_hidden files?
 .PP

--- a/src/getxattr.cpp
+++ b/src/getxattr.cpp
@@ -161,8 +161,8 @@ _getxattr_controlfile_errno(const int  errno_,
     case ENOATTR:
       attrvalue = "noattr";
       break;
-    case ENOTSUP:
-      attrvalue = "notsup";
+    case ENOSYS:
+      attrvalue = "nosys";
       break;
     default:
       attrvalue = "ERROR";

--- a/src/option_parser.cpp
+++ b/src/option_parser.cpp
@@ -160,8 +160,8 @@ parse_and_process_errno(const std::string &value_,
 {
   if(value_ == "passthrough")
     errno_ = 0;
-  else if(value_ == "notsup")
-    errno_ = ENOTSUP;
+  else if(value_ == "nosys")
+    errno_ = ENOSYS;
   else if(value_ == "noattr")
     errno_ = ENOATTR;
   else
@@ -365,11 +365,11 @@ usage(void)
     "    -o security_capability=<bool>\n"
     "                           When disabled return ENOATTR when the xattr\n"
     "                           security.capability is queried. default = true\n"
-    "    -o xattr=passthrough|noattr|notsup\n"
+    "    -o xattr=passthrough|noattr|nosys\n"
     "                           Runtime control of xattrs. By default xattr\n"
     "                           requests will pass through to the underlying\n"
     "                           filesystems. notattr will short circuit as if\n"
-    "                           nothing exists. notsup will respond as if not\n"
+    "                           nothing exists. nosys will respond as if not\n"
     "                           supported or disabled. default = passthrough\n"
     "    -o statfs=base|full    When set to 'base' statfs will use all branches\n"
     "                           when performing statfs calculations. 'full' will\n"

--- a/src/setxattr.cpp
+++ b/src/setxattr.cpp
@@ -169,8 +169,8 @@ _setxattr_xattr(const string &attrval_,
     xattr_ = 0;
   else if(attrval_ == "noattr")
     xattr_ = ENOATTR;
-  else if(attrval_ == "notsup")
-    xattr_ = ENOTSUP;
+  else if(attrval_ == "nosys")
+    xattr_ = ENOSYS;
   else
     return -EINVAL;
 


### PR DESCRIPTION
ENOSYS is the correct return to short circuit xattr calls at the kernel. Not ENOTSUP.