### PR TITLE
fix renaming over open unlinked file

### DIFF
--- a/tests/TEST_unlink_rename
+++ b/tests/TEST_unlink_rename
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import tempfile
+
+(srcfd,src) = tempfile.mkstemp(dir=sys.argv[1])
+(tgtfd,tgt) = tempfile.mkstemp(dir=sys.argv[1])
+
+os.unlink(tgt)
+os.rename(src,tgt)
+
+os.close(srcfd)
+os.close(tgtfd)


### PR DESCRIPTION
There was a bug with renaming over opened unlinked files which have been marked "hidden". This was an edgecase with the change to remove .fuse_hidden files.