### PR TITLE
Force symlink creation (don't error if it already exists)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ install-base: build/mergerfs
 
 install-mount.mergerfs: install-base
 	$(MKDIR) -p "$(INSTALLBINDIR)"
-	$(LN) -s "mergerfs" "$(INSTALLBINDIR)/mount.mergerfs"
+	$(LN) -fs "mergerfs" "$(INSTALLBINDIR)/mount.mergerfs"
 
 install-man: $(MANPAGE)
 	$(MKDIR) -p "$(INSTALLMAN1DIR)"


### PR DESCRIPTION
Currently, reinstalling or upgrading mergerfs via the Makefile gives an error, because the symlink mount.mergerfs already exists:

```
ln -s "mergerfs" "/usr/local/bin/mount.mergerfs"
ln: /usr/local/bin/mount.mergerfs: File exists
gmake: *** [Makefile:153: install-mount.mergerfs] Error 1
```

This fixes that error by removing and recreating the symlink if it already exists, rather than erroring.

As this is a Makefile it would also be possible to make it do nothing if the symlink already exists, rather than recreating it. It seemed like the general pattern of the Makefile was not to worry about such things, but I could do it that way if you want.