### PR TITLE
Configure Cirrus-CI to test compiling on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,10 @@
+freebsd_instance:
+  image_family: freebsd-12-1
+
+task:
+  name: compile
+  env:
+    ASSUME_ALWAYS_YES: yes
+  script:
+    - ./tools/install-build-pkgs
+    - gmake


### PR DESCRIPTION
NB: This is really more of an experiment/demo than a request to merge. In particular right now this would be a bad idea to merge because of #761, unless you want to be reminded about it on every commit!

As was mentioned in #661, Cirrus CI supports FreeBSD, and I thought I'd give it a go to see if it's viable for testing mergerfs.

The short summary of my experimentation is that it does work! It's quite slow and the interface is very basic compared to Travis, but it's free so it's hard to complain.

I have set it up on [my copy of this repo](https://github.com/zofrex/mergerfs/branches) so you can see it easily in action, you can see both a failing branch and a passing branch there: [version 2.8.3](https://github.com/zofrex/mergerfs/runs/747401136) is passing as expected, and [2.29.0](https://github.com/zofrex/mergerfs/runs/747525708) is failing as expected.

I'm not sure there's any specific call to action here, but hopefully it's useful information.