### PR TITLE
temporary fix for short readdirs on NFS

### DIFF
--- a/libfuse/lib/fuse.c
+++ b/libfuse/lib/fuse.c
@@ -3498,7 +3498,7 @@ fuse_lib_readdir(fuse_req_t             req_,
   pthread_mutex_lock(&dh->lock);
 
   rv = 0;
-  if(off_ == 0)
+  if((off_ == 0) || (d->data_len == 0))
     rv = readdir_fill(f,req_,d,&fi);
 
   if(rv)
@@ -3544,7 +3544,7 @@ fuse_lib_readdir_plus(fuse_req_t             req_,
   pthread_mutex_lock(&dh->lock);
 
   rv = 0;
-  if(off_ == 0)
+  if((off_ == 0) || (d->data_len == 0))
     rv = readdir_plus_fill(f,req_,d,&fi);
 
   if(rv)


### PR DESCRIPTION
While this replicates the original libfuse2 behavior it can result in bad data being sent to the kernel. A future patch will address this in a safer way.