### PR TITLE
Makefiles fixes: support environmental passed $AR, $CFLAGS, $CXXFLAGS and $LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,14 @@ SRC	    = $(wildcard src/*.cpp)
 OBJS        = $(SRC:src/%.cpp=build/%.o)
 DEPS        = $(SRC:src/%.cpp=build/%.d)
 MANPAGE     = mergerfs.1
-CXXFLAGS    = \
+CXXFLAGS    ?= ${OPT_FLAGS}
+CXXFLAGS    := \
+              ${CXXFLAGS} \
               -std=c++0x \
-              $(OPT_FLAGS) \
               $(STATIC_FLAGS) \
               $(LTO_FLAGS) \
               -Wall \
-	      -Wno-unused-result \
+              -Wno-unused-result \
               -MMD
 FUSE_FLAGS = \
               -Ilibfuse/include \
@@ -76,9 +77,11 @@ FUSE_FLAGS = \
 MFS_FLAGS  = \
 	      -DUSE_XATTR=$(USE_XATTR) \
 	      -DUGID_USE_RWLOCK=$(UGID_USE_RWLOCK)
-LDFLAGS    = \
-	      -pthread \
-              -lrt
+
+LDFLAGS := \
+    ${LDFLAGS} \
+    -pthread \
+    -lrt
 
 DESTDIR       =
 PREFIX        = /usr/local

--- a/libfuse/Makefile
+++ b/libfuse/Makefile
@@ -29,6 +29,8 @@ INSTALLBINDIR  = $(DESTDIR)$(BINDIR)
 INSTALLSBINDIR = $(DESTDIR)$(SBINDIR)
 INSTALLMAN1DIR = $(DESTDIR)$(MAN1DIR)
 
+AR ?= ar
+
 SRC   = \
 	lib/buffer.c \
 	lib/cuse_lowlevel.c \
@@ -78,7 +80,7 @@ objects: build/config.h
 	$(MAKE) $(OBJS)
 
 build/libfuse.a: objects
-	ar rcs build/libfuse.a $(OBJS)
+	${AR} rcs build/libfuse.a $(OBJS)
 
 utils: mergerfs-fusermount mount.mergerfs
 

--- a/libfuse/Makefile
+++ b/libfuse/Makefile
@@ -48,9 +48,10 @@ SRC   = \
 	lib/mount.c
 OBJS = $(SRC:lib/%.c=build/%.o)
 DEPS = $(SRC:lib/%.c=build/%.d)
-
-CFLAGS = \
-	$(OPT_FLAGS) \
+CFLAGS ?= \
+	$(OPT_FLAGS)
+CFLAGS := \
+    ${CFLAGS} \
 	-Wall \
 	-pipe \
 	-MMD
@@ -63,7 +64,8 @@ FUSE_FLAGS = \
 	-DFUSE_USE_VERSION=29 \
 	-DPACKAGE_VERSION=\"$(VERSION)\" \
 	-DFUSERMOUNT_DIR=\"$(FUSERMOUNT_DIR)\"
-LDFLAGS = \
+LDFLAGS := \
+	${LDFLAGS} \
 	-lrt \
 	-pthread
 


### PR DESCRIPTION
This changeset allows for to change default CFLAGS/CXXFLAGS/LDFLAGS as well as set custom `ar` using environmental variables, while still adding the additional non-optional flags even if user pushes their own flags. Unless those variables are set, buildsystem of libfuse and mergerfs acts the same way it did before those changes.

Those changes exist to fix bugs reported under:

- https://bugs.gentoo.org/725978
- https://bugs.gentoo.org/728158
