### PR TITLE
Update percentage full expiring script

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ do
                   head -n 1 | \
                   cut -d' ' -f2-)
     test -n "${FILE}"
-    rsync -axqHAXWES --preallocate --remove-source-files "${CACHE}/./${FILE}" "${BACKING}/"
+    rsync -axqHAXWESR --preallocate --remove-source-files "${CACHE}/./${FILE}" "${BACKING}/"
 done
 ```
 


### PR DESCRIPTION
Have added the relative option for rsync. Previously it would dump all files into the root of the backing drive, adding relative puts it into the same subdirectory as it was located in on the cache drive. 