### PR TITLE
Fix query of attr during symlink

### DIFF
--- a/src/fuse_link.cpp
+++ b/src/fuse_link.cpp
@@ -239,8 +239,9 @@ namespace l
     if(rv == 0)
       rv = FUSE::getattr(oldpath_,st_,timeouts_);
 
-    // Disable attr caching since we created a symlink but should be a regular.
-    timeouts_->attr = 0;
+    // Disable caching since we created a symlink but should be a regular.
+    timeouts_->attr  = 0;
+    timeouts_->entry = 0;
 
     return rv;
   }
@@ -268,8 +269,9 @@ namespace l
     if(rv == 0)
       rv = FUSE::getattr(oldpath_,st_,timeouts_);
 
-    // Disable attr caching since we created a symlink but should be a regular.
-    timeouts_->attr = 0;
+    // Disable caching since we created a symlink but should be a regular.
+    timeouts_->attr  = 0;
+    timeouts_->entry = 0;
 
     return rv;
   }
@@ -292,8 +294,9 @@ namespace l
     if(rv == 0)
       rv = FUSE::getattr(oldpath_,st_,timeouts_);
 
-    // Disable attr caching since we created a symlink but should be a regular.
-    timeouts_->attr = 0;
+    // Disable caching since we created a symlink but should be a regular.
+    timeouts_->attr  = 0;
+    timeouts_->entry = 0;
 
     return rv;
   }

--- a/src/fuse_symlink.hpp
+++ b/src/fuse_symlink.hpp
@@ -23,12 +23,8 @@
 namespace FUSE
 {
   int
-  symlink(const char *target,
-          const char *linkpath);
-
-  int
   symlink(const char      *target,
           const char      *linkpath,
-          struct stat     *st,
-          fuse_timeouts_t *timeouts);
+          struct stat     *st       = NULL,
+          fuse_timeouts_t *timeouts = NULL);
 }


### PR DESCRIPTION
Using getattr when follow-symlink is enabled causes invalid type to the kernel
if symlink pointed to non-symlink.