### PR TITLE
Change ENOENT to ESTALE for looking up paths to handle rename race conditions

### DIFF
--- a/libfuse/lib/fuse.c
+++ b/libfuse/lib/fuse.c
@@ -921,7 +921,7 @@ try_get_path(struct fuse  *f,
 
   for(node = get_node(f,nodeid); node->nodeid != FUSE_ROOT_ID; node = node->parent)
     {
-      err = -ENOENT;
+      err = -ESTALE;
       if(node->name == NULL || node->parent == NULL)
         goto out_unlock;
 


### PR DESCRIPTION
As done in https://github.com/libfuse/libfuse/pull/636