### PR TITLE
Remove 'nonempty' argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ make LTO=1            - build with link time optimization
 
 mergerfs can be upgraded live by mounting on top of the previous instance. Simply install the new version of mergerfs and follow the instructions below.
 
-Add `nonempty` to your mergerfs option list and call mergerfs again or if using `/etc/fstab` call for it to mount again. Existing open files and such will continue to work fine though they won't see runtime changes since any such change would be the new mount. If you plan on changing settings with the new mount you should / could apply those before mounting the new version.
+Run mergerfs again or if using `/etc/fstab` call for it to mount again. Existing open files and such will continue to work fine though they won't see runtime changes since any such change would be the new mount. If you plan on changing settings with the new mount you should / could apply those before mounting the new version.
 
 ```
 $ sudo mount /mnt/mergerfs

--- a/libfuse/lib/mount_bsd.c
+++ b/libfuse/lib/mount_bsd.c
@@ -90,7 +90,6 @@ static const struct fuse_opt fuse_mount_opts[] = {
    * handle them
    */
   FUSE_OPT_KEY("fsname=",			KEY_KERN),
-  FUSE_OPT_KEY("nonempty",		KEY_KERN),
   FUSE_OPT_KEY("large_read",		KEY_KERN),
   FUSE_OPT_END
 };

--- a/libfuse/lib/mount_generic.c
+++ b/libfuse/lib/mount_generic.c
@@ -64,7 +64,6 @@ struct mount_opts {
   int allow_other;
   int ishelp;
   int flags;
-  int nonempty;
   int auto_unmount;
   int blkdev;
   char *fsname;
@@ -79,13 +78,11 @@ struct mount_opts {
 
 static const struct fuse_opt fuse_mount_opts[] = {
   FUSE_MOUNT_OPT("allow_other",		allow_other),
-  FUSE_MOUNT_OPT("nonempty",		nonempty),
   FUSE_MOUNT_OPT("blkdev",		blkdev),
   FUSE_MOUNT_OPT("auto_unmount",		auto_unmount),
   FUSE_MOUNT_OPT("fsname=%s",		fsname),
   FUSE_MOUNT_OPT("subtype=%s",		subtype),
   FUSE_OPT_KEY("allow_other",		KEY_KERN_OPT),
-  FUSE_OPT_KEY("nonempty",		KEY_FUSERMOUNT_OPT),
   FUSE_OPT_KEY("auto_unmount",		KEY_FUSERMOUNT_OPT),
   FUSE_OPT_KEY("blkdev",			KEY_FUSERMOUNT_OPT),
   FUSE_OPT_KEY("fsname=",			KEY_FUSERMOUNT_OPT),
@@ -126,7 +123,6 @@ static void mount_help(void)
   fprintf(stderr,
           "    -o allow_other         allow access to other users\n"
           "    -o auto_unmount        auto unmount on process termination\n"
-          "    -o nonempty            allow mounts over non-empty file/dir\n"
           "    -o default_permissions enable permission checking by kernel\n"
           "    -o fsname=NAME         set filesystem name\n"
           "    -o subtype=NAME        set filesystem type\n"
@@ -422,13 +418,6 @@ static int fuse_mount_sys(const char *mnt, struct mount_opts *mo,
     fprintf(stderr ,"fuse: failed to access mountpoint %s: %s\n",
             mnt, strerror(errno));
     return -1;
-  }
-
-  if (!mo->nonempty) {
-    res = fuse_mnt_check_empty("fuse", mnt, stbuf.st_mode,
-                               stbuf.st_size);
-    if (res == -1)
-      return -1;
   }
 
   if (mo->auto_unmount) {

--- a/libfuse/lib/mount_util.c
+++ b/libfuse/lib/mount_util.c
@@ -312,39 +312,6 @@ char *fuse_mnt_resolve_path(const char *progname, const char *orig)
   return dst;
 }
 
-int fuse_mnt_check_empty(const char *progname, const char *mnt,
-			 mode_t rootmode, off_t rootsize)
-{
-  int isempty = 1;
-
-  if (S_ISDIR(rootmode)) {
-    struct dirent *ent;
-    DIR *dp = opendir(mnt);
-    if (dp == NULL) {
-      fprintf(stderr,
-              "%s: failed to open mountpoint for reading: %s\n",
-              progname, strerror(errno));
-      return -1;
-    }
-    while ((ent = readdir(dp)) != NULL) {
-      if (strcmp(ent->d_name, ".") != 0 &&
-          strcmp(ent->d_name, "..") != 0) {
-        isempty = 0;
-        break;
-      }
-    }
-    closedir(dp);
-  } else if (rootsize)
-    isempty = 0;
-
-  if (!isempty) {
-    fprintf(stderr, "%s: mountpoint is not empty\n", progname);
-    fprintf(stderr, "%s: if you are sure this is safe, use the 'nonempty' mount option\n", progname);
-    return -1;
-  }
-  return 0;
-}
-
 int fuse_mnt_check_fuseblk(void)
 {
   char buf[256];

--- a/libfuse/lib/mount_util.h
+++ b/libfuse/lib/mount_util.h
@@ -16,6 +16,4 @@ int fuse_mnt_remove_mount(const char *progname, const char *mnt);
 int fuse_mnt_umount(const char *progname, const char *abs_mnt,
 		    const char *rel_mnt, int lazy);
 char *fuse_mnt_resolve_path(const char *progname, const char *orig);
-int fuse_mnt_check_empty(const char *progname, const char *mnt,
-			 mode_t rootmode, off_t rootsize);
 int fuse_mnt_check_fuseblk(void);

--- a/libfuse/util/fusermount.c
+++ b/libfuse/util/fusermount.c
@@ -726,7 +726,6 @@ static int do_mount(const char *mnt, char **typep, mode_t rootmode,
 	char *subtype = NULL;
 	char *source = NULL;
 	char *type = NULL;
-	int check_empty = 1;
 	int blkdev = 0;
 
 	optbuf = (char *) malloc(strlen(opts) + 128);
@@ -759,8 +758,6 @@ static int do_mount(const char *mnt, char **typep, mode_t rootmode,
 				goto err;
 			}
 			blkdev = 1;
-		} else if (opt_eq(s, len, "nonempty")) {
-			check_empty = 0;
 		} else if (opt_eq(s, len, "auto_unmount")) {
 			auto_unmount = 1;
 		} else if (!begins_with(s, "fd=") &&
@@ -810,10 +807,6 @@ static int do_mount(const char *mnt, char **typep, mode_t rootmode,
 
 	sprintf(d, "fd=%i,rootmode=%o,user_id=%u,group_id=%u",
 		fd, rootmode, getuid(), getgid());
-
-	if (check_empty &&
-	    fuse_mnt_check_empty(progname, mnt, rootmode, rootsize) == -1)
-		goto err;
 
 	source = malloc((fsname ? strlen(fsname) : 0) +
 			(subtype ? strlen(subtype) : 0) + strlen(dev) + 32);

--- a/libfuse/util/mount_util.c
+++ b/libfuse/util/mount_util.c
@@ -312,39 +312,6 @@ char *fuse_mnt_resolve_path(const char *progname, const char *orig)
 	return dst;
 }
 
-int fuse_mnt_check_empty(const char *progname, const char *mnt,
-			 mode_t rootmode, off_t rootsize)
-{
-	int isempty = 1;
-
-	if (S_ISDIR(rootmode)) {
-		struct dirent *ent;
-		DIR *dp = opendir(mnt);
-		if (dp == NULL) {
-			fprintf(stderr,
-				"%s: failed to open mountpoint for reading: %s\n",
-				progname, strerror(errno));
-			return -1;
-		}
-		while ((ent = readdir(dp)) != NULL) {
-			if (strcmp(ent->d_name, ".") != 0 &&
-			    strcmp(ent->d_name, "..") != 0) {
-				isempty = 0;
-				break;
-			}
-		}
-		closedir(dp);
-	} else if (rootsize)
-		isempty = 0;
-
-	if (!isempty) {
-		fprintf(stderr, "%s: mountpoint is not empty\n", progname);
-		fprintf(stderr, "%s: if you are sure this is safe, use the 'nonempty' mount option\n", progname);
-		return -1;
-	}
-	return 0;
-}
-
 int fuse_mnt_check_fuseblk(void)
 {
 	char buf[256];


### PR DESCRIPTION
This makes it like all other filesystems and brings it into alignment with libfuse3's behavior.