### PR TITLE
Fix config file parsing

### DIFF
--- a/src/branches.cpp
+++ b/src/branches.cpp
@@ -80,6 +80,9 @@ namespace l
     uint64_t offset;
 
     offset = s_.find_first_not_of("+<>-=");
+    if (offset == std::string::npos) {
+      offset = s_.length();
+    }
     if(offset > 1)
       offset = 2;
     *instr_ = s_.substr(0,offset);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -86,6 +86,9 @@ test_config_branches()
   TEST_CHECK(b->minfreespace() == 1234);
   TEST_CHECK(b.to_string() == "");
 
+  // Parse initial value for branch
+  TEST_CHECK(b.from_string(b.to_string()) == 0);
+
   bcp0 = b;
   TEST_CHECK(b.from_string("/foo/bar") == 0);
   TEST_CHECK(b.to_string() == "/foo/bar=RW");


### PR DESCRIPTION
Motivating case:
```
$ ./mergerfs -o config=any.conf aaa testmnt
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::substr: __pos (which is 2) > this->size() (which is 0)
Aborted (core dumped)
```

The content of the config file is irrelevant, the relevant stack is:
```
#10 0x000000000040cc4e in Branches::Impl::from_string (this=0x680540, s_="") at src/branches.cpp:316
#11 0x000000000040d8e7 in Branches::from_string (this=0x7fffffffc500, str_="") at src/branches.cpp:381
#12 0x000000000042da04 in Config::operator= (this=0x7fffffffc4d0, cfg_=...) at src/config.cpp:193
#13 0x000000000042ecab in Config::from_stream (this=0x666d80 <Config::_singleton>, istrm_=..., errs_=0x7fffffffd4b0) at src/config.cpp:302
#14 0x000000000042f93e in Config::from_file (this=0x666d80 <Config::_singleton>, filepath_="empty.conf", errs_=0x7fffffffd4b0) at src/config.cpp:341
```

The error happens while trying to assign the initial config object to the new instance in `Config::from_stream`. Empty branch (initial value) cannot be parsed by `from_branch()`. In fact having `branch=` line in the config would have the same result.

I also created a test, which explains the issue.