### PR TITLE
Make srcmounts readonly

### DIFF
--- a/src/branches.cpp
+++ b/src/branches.cpp
@@ -424,7 +424,8 @@ SrcMounts::SrcMounts(Branches &b_)
 int
 SrcMounts::from_string(const std::string &s_)
 {
-  return _branches.from_string(s_);
+  //  return _branches.from_string(s_);
+  return 0;
 }
 
 std::string

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -68,6 +68,7 @@ namespace l
     IFERT("read-thread-count");
     IFERT("readdirplus");
     IFERT("scheduling-priority");
+    IFERT("srcmounts");
     IFERT("threads");
     IFERT("version");
 


### PR DESCRIPTION
All tools only read from srcmounts and the current setup had a bug which caused branch mode and minfreespace to be stripped when using config file.