### PR TITLE
Fix build on older distros due to std::atomic definitions

### DIFF
--- a/libfuse/lib/fuse_msgbuf.cpp
+++ b/libfuse/lib/fuse_msgbuf.cpp
@@ -30,7 +30,7 @@
 static std::uint32_t g_PAGESIZE = 0;
 static std::uint32_t g_BUFSIZE  = 0;
 
-static std::atomic_uint64_t g_MSGBUF_ALLOC_COUNT;
+static std::atomic<std::uint_fast64_t> g_MSGBUF_ALLOC_COUNT;
 
 static std::mutex g_MUTEX;
 static std::vector<fuse_msgbuf_t*> g_MSGBUF_STACK;


### PR DESCRIPTION
std::atomic_uint64_t missing in some older distros