### PR TITLE
Docs: clarify parallel-direct-writes and cache.files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1294,12 +1294,12 @@ https://en.wikipedia.org/wiki/Page_cache
   unchanged since previous open.
 * cache.files=libfuse: follow traditional libfuse `direct_io`,
   `kernel_cache`, and `auto_cache` arguments.
-* cache.files=per-process: Enable page caching only for processes
-  which 'comm' name matches one of the values defined in
-  `cache.files.process-names`.
+* cache.files=per-process: Enable page caching (equivalent to `cache.files=partial`) 
+  only for processes which 'comm' name matches one of the values defined in
+  `cache.files.process-names`. If the name does not match the file open
+  is equivalent to `cache.files=off`.
 
-FUSE, which mergerfs uses, offers a number of page caching
-modes. mergerfs tries to simplify their use via the `cache.files`
+FUSE, which mergerfs uses, offers a number of page caching modes. mergerfs tries to simplify their use via the `cache.files`
 option. It can and should replace usage of `direct_io`,
 `kernel_cache`, and `auto_cache`.
 

--- a/README.md
+++ b/README.md
@@ -1295,7 +1295,7 @@ https://en.wikipedia.org/wiki/Page_cache
 * cache.files=libfuse: follow traditional libfuse `direct_io`,
   `kernel_cache`, and `auto_cache` arguments.
 * cache.files=per-process: Enable page caching (equivalent to `cache.files=partial`) 
-  only for processes which 'comm' name matches one of the values defined in
+  only for processes whose 'comm' name matches one of the values defined in
   `cache.files.process-names`. If the name does not match the file open
   is equivalent to `cache.files=off`.
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ These options are the same regardless of whether you use them with the
   (default: false)
 * **parallel-direct-writes=BOOL**: Allow the kernel to dispatch
   multiple, parallel (non-extending) write requests for files opened
-  with `direct_io=true` (if supported by the kernel)
+  with `cache.files=per-process` (if the process is not in `process-names`)
+  or `cache.files=off`. (This requires kernel support, and was added in v6.2)
 * **direct_io**: deprecated - Bypass page cache. Use `cache.files=off`
   instead. (default: false)
 * **kernel_cache**: deprecated - Do not invalidate data cache on file


### PR DESCRIPTION
Clarifies some points around cache.files and parallel-direct-writes. See commit messages for details:

Tl;dr:

- Make it clear which kernel versions support `parallel-direct-writes`
~- Steer people to use `cache.files=off` instead of `direct_io`~
~- Clarify which each `cache.files` implies, so people with existing mount options can (hopefully) say, I can consolidate my mount flags into `cache.files=foo`~
- Make it clear that per-process will act the same as `cache.files=off` is the process name does not match