### PR TITLE
Update document on allow_other to reflect latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ These options are the same regardless of whether you use them with the
   multiple, parallel (non-extending) write requests for files opened
   with `cache.files=per-process` (if the process is not in `process-names`)
   or `cache.files=off`. (This requires kernel support, and was added in v6.2)
+* **allow_other**: Allow other users to access files. Set by default when running as root.
 * **direct_io**: deprecated - Bypass page cache. Use `cache.files=off`
   instead. (default: false)
 * **kernel_cache**: deprecated - Do not invalidate data cache on file
@@ -307,7 +308,6 @@ These options are the same regardless of whether you use them with the
 * **splice_read**: deprecated - Does nothing.
 * **splice_write**: deprecated - Does nothing.
 * **splice_move**: deprecated - Does nothing.
-* **allow_other**: Allow other users to access files. Set by default when running as root.
 * **use_ino**: deprecated - mergerfs should always control inode
   calculation so this is enabled all the time.
 

--- a/README.md
+++ b/README.md
@@ -307,8 +307,7 @@ These options are the same regardless of whether you use them with the
 * **splice_read**: deprecated - Does nothing.
 * **splice_write**: deprecated - Does nothing.
 * **splice_move**: deprecated - Does nothing.
-* **allow_other**: deprecated - mergerfs always sets this FUSE option
-  as normal permissions can be used to limit access.
+* **allow_other**: Allow other users to access files. Set by default when running as root.
 * **use_ino**: deprecated - mergerfs should always control inode
   calculation so this is enabled all the time.
 

--- a/man/mergerfs.1
+++ b/man/mergerfs.1
@@ -402,6 +402,8 @@ multiple, parallel (non-extending) write requests for files opened with
 \f[C]process-names\f[R]) or \f[C]cache.files=off\f[R].
 (This requires kernel support, and was added in v6.2)
 .IP \[bu] 2
+\f[B]allow_other\f[R]: Allow other users to access files. Set by default when running as root.
+.IP \[bu] 2
 \f[B]direct_io\f[R]: deprecated - Bypass page cache.
 Use \f[C]cache.files=off\f[R] instead.
 (default: false)
@@ -427,9 +429,6 @@ Use \f[C]async_read=false\f[R] instead.
 \f[B]splice_write\f[R]: deprecated - Does nothing.
 .IP \[bu] 2
 \f[B]splice_move\f[R]: deprecated - Does nothing.
-.IP \[bu] 2
-\f[B]allow_other\f[R]: deprecated - mergerfs always sets this FUSE
-option as normal permissions can be used to limit access.
 .IP \[bu] 2
 \f[B]use_ino\f[R]: deprecated - mergerfs should always control inode
 calculation so this is enabled all the time.


### PR DESCRIPTION
The behaviour was changed on https://github.com/trapexit/mergerfs/commit/d6a2f067979186eb1c8422317ea2816d98eee083