### PR TITLE
Basepath-hash inode algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ These options are the same regardless of whether you use them with the
   the file. An attempt to move the file to that branch will occur
   (keeping all metadata possible) and if successful the original is
   unlinked and the write retried. (default: false, true = mfs)
-* **inodecalc=passthrough|path-hash|devino-hash|hybrid-hash**: Selects
-  the inode calculation algorithm. (default: hybrid-hash)
+* **inodecalc=passthrough|path-hash|devino-hash|basepath-hash|hybrid-hash|basehybrid-hash**:
+  Selects the inode calculation algorithm. (default: hybrid-hash)
 * **dropcacheonclose=BOOL**: When a file is requested to be closed
   call `posix_fadvise` on it first to instruct the kernel that we no
   longer need the data and it can drop its cache. Recommended when
@@ -444,12 +444,23 @@ covering different usecases.
   different file or files move out of band but will present the same
   inode for underlying files that do too.
 * devino-hash32: 32bit version of devino-hash.
+* basepath-hash: Hashes the branch base path along with
+  the inode of the underlying entry.  This has a similar purpose to
+  devino-hash, but by using the path instead of the device-id, the inodes
+  will be guaranteed to be stable across reboots.  Useful for backup or
+  deduplication systems that rely on a static inode.  Note that if the
+  root directory is below the mountpoint of the underlying storage,
+  duplicate inodes are possible.
+* basepath-hash32: 32bit version of basepath-hash.
 * hybrid-hash: Performs `path-hash` on directories and `devino-hash`
   on other file types. Since directories can't have hard links the
   static value won't make a difference and the files will get values
   useful for finding duplicates. Probably the best to use if not using
   NFS. As such it is the default.
 * hybrid-hash32: 32bit version of hybrid-hash.
+* basehybrid-hash: Serves the same purpose as `hybrid-hash` but using
+  the `basepath-hash` algorithm for files.
+* basehybrid-hash32: 32bit version of basehybrid-hash
 
 32bit versions are provided as there is some software which does not
 handle 64bit inodes well.

--- a/src/fileinfo.hpp
+++ b/src/fileinfo.hpp
@@ -27,16 +27,19 @@ class FileInfo : public FH
 {
 public:
   FileInfo(int const   fd_,
+           const std::string &basepath_,
            char const *fusepath_,
            bool const  direct_io_)
     : FH(fusepath_),
       fd(fd_),
+      basepath(basepath_),
       direct_io(direct_io_)
   {
   }
 
 public:
   int fd;
+  const std::string basepath;
   uint32_t direct_io:1;
   std::mutex mutex;
 };

--- a/src/fs_inode.hpp
+++ b/src/fs_inode.hpp
@@ -33,21 +33,26 @@ namespace fs
     int set_algo(const std::string &s);
     std::string get_algo(void);
 
-    uint64_t calc(const char     *fusepath,
+    uint64_t calc(const std::string &basepath,
+                  const char     *fusepath,
                   const uint64_t  fusepath_len,
                   const mode_t    mode,
                   const dev_t     dev,
                   const ino_t     ino);
-    uint64_t calc(std::string const &fusepath,
+    uint64_t calc(const std::string &basepath,
+                  std::string const &fusepath,
                   mode_t const       mode,
                   dev_t const        dev,
                   ino_t              ino);
-    void calc(const char     *fusepath,
+    void calc(const std::string &basepath,
+              const char     *fusepath,
               const uint64_t  fusepath_len,
               struct stat    *st);
-    void calc(const char  *fusepath,
+    void calc(const std::string &basepath,
+              const char  *fusepath,
               struct stat *st);
-    void calc(const std::string &fusepath,
+    void calc(const std::string &basepath,
+              const std::string &fusepath,
               struct stat       *st);
 
   }

--- a/src/fuse_create.cpp
+++ b/src/fuse_create.cpp
@@ -163,7 +163,7 @@ namespace l
     if(rv == -1)
       return -errno;
 
-    fi = new FileInfo(rv,fusepath_,ffi_->direct_io);
+    fi = new FileInfo(rv,createpath_,fusepath_,ffi_->direct_io);
 
     ffi_->fh = reinterpret_cast<uint64_t>(fi);
 

--- a/src/fuse_fgetattr.cpp
+++ b/src/fuse_fgetattr.cpp
@@ -28,6 +28,7 @@ namespace l
   static
   int
   fgetattr(const int          fd_,
+           const std::string &basepath_,
            const std::string &fusepath_,
            struct stat       *st_)
   {
@@ -37,7 +38,7 @@ namespace l
     if(rv == -1)
       return -errno;
 
-    fs::inode::calc(fusepath_,st_);
+    fs::inode::calc(basepath_,fusepath_,st_);
 
     return 0;
   }
@@ -54,7 +55,7 @@ namespace FUSE
     Config::Read cfg;
     FileInfo *fi = reinterpret_cast<FileInfo*>(ffi_->fh);
 
-    rv = l::fgetattr(fi->fd,fi->fusepath,st_);
+    rv = l::fgetattr(fi->fd,fi->basepath,fi->fusepath,st_);
 
     timeout_->entry = ((rv >= 0) ?
                        cfg->cache_entry :

--- a/src/fuse_getattr.cpp
+++ b/src/fuse_getattr.cpp
@@ -141,7 +141,7 @@ namespace l
     if(symlinkify_ && symlinkify::can_be_symlink(*st_,symlinkify_timeout_))
       symlinkify::convert(fullpath,st_);
 
-    fs::inode::calc(fusepath_,st_);
+    fs::inode::calc(basepaths[0],fusepath_,st_);
 
     return 0;
   }

--- a/src/fuse_open.cpp
+++ b/src/fuse_open.cpp
@@ -211,7 +211,7 @@ namespace l
     if(fd == -1)
       return -errno;
 
-    fi = new FileInfo(fd,fusepath_,ffi_->direct_io);
+    fi = new FileInfo(fd,basepath_,fusepath_,ffi_->direct_io);
 
     ffi_->fh = reinterpret_cast<uint64_t>(fi);
 

--- a/src/fuse_readdir_cor.cpp
+++ b/src/fuse_readdir_cor.cpp
@@ -77,7 +77,8 @@ namespace l
   static
   inline
   int
-  readdir(std::string     basepath_,
+  readdir(const std::string    &branchdir_,
+          std::string    basepath_,
           HashSet        &names_,
           fuse_dirents_t *buf_,
           std::mutex     &mutex_)
@@ -122,7 +123,8 @@ namespace l
               continue;
 
             filepath = fs::path::make(basepath_,d->name);
-            d->ino = fs::inode::calc(filepath,
+            d->ino = fs::inode::calc(branchdir_,
+                                     filepath,
                                      DTTOIF(d->type),
                                      dev,
                                      d->ino);
@@ -161,7 +163,7 @@ namespace l
 
           basepath = fs::path::make(branch.path,dirname_);
 
-          return l::readdir(basepath,names,buf_,mutex);
+          return l::readdir(branch.path,basepath,names,buf_,mutex);
         };
 
         auto rv = tp_.enqueue_task(func);

--- a/src/fuse_readdir_cosr.cpp
+++ b/src/fuse_readdir_cosr.cpp
@@ -52,6 +52,7 @@ namespace l
   {
     DIR *dir;
     int  err;
+    std::string basepath;
   };
 
   struct Error
@@ -119,6 +120,7 @@ namespace l
           errno  = 0;
           rv.dir = fs::opendir(basepath);
           rv.err = errno;
+          rv.basepath = branch.path;
 
           return rv;
         };
@@ -169,7 +171,8 @@ namespace l
               continue;
 
             fullpath  = fs::path::make(dirname_,de->d_name);
-            de->d_ino = fs::inode::calc(fullpath,
+            de->d_ino = fs::inode::calc(dirrv.basepath,
+                                        fullpath,
                                         DTTOIF(de->d_type),
                                         dev,
                                         de->d_ino);

--- a/src/fuse_readdir_seq.cpp
+++ b/src/fuse_readdir_seq.cpp
@@ -125,7 +125,8 @@ namespace l
               continue;
 
             fullpath = fs::path::make(dirname_,de->d_name);
-            de->d_ino = fs::inode::calc(fullpath,
+            de->d_ino = fs::inode::calc(branch.path,
+                                        fullpath,
                                         DTTOIF(de->d_type),
                                         dev,
                                         de->d_ino);

--- a/src/fuse_symlink.cpp
+++ b/src/fuse_symlink.cpp
@@ -74,7 +74,7 @@ namespace l
       {
         fs::lstat(fullnewpath,st_);
         if(st_->st_ino != 0)
-          fs::inode::calc(linkpath_,st_);
+          fs::inode::calc(newbasepath_,linkpath_,st_);
       }
 
     return error::calc(rv,error_,errno);


### PR DESCRIPTION
This is an updated version of the patch from https://github.com/trapexit/mergerfs/discussions/1002

I ran into a similar issue recently where after replacing the SATA controller, the device-ids all changed, and my backup tool which relies on inodes being consistent got very confused.

This is just the patch from @thrnz cleaned up for 2.40.2, with the addition of README updates for the changes.