### PR TITLE
Add missing --relative flag to rsync in percent-full mover script

### DIFF
--- a/tools/mergerfs.percent-full-mover
+++ b/tools/mergerfs.percent-full-mover
@@ -17,5 +17,5 @@ do
                   head -n 1 | \
                   cut -d' ' -f2-)
     test -n "${FILE}"
-    rsync -axqHAXWESR --preallocate --remove-source-files "${CACHE}/./${FILE}" "${BACKING}/"
+    rsync -axqHAXWESR --preallocate --relative --remove-source-files "${CACHE}/./${FILE}" "${BACKING}/"
 done


### PR DESCRIPTION
The mergerfs.percent-full-mover script is missing the --relative flag for rsync.

It currently moves all files into the root of the destination. Adding the --relative flag fixes that, and paths are then correctly preserved.
