### PR TITLE
Update the secondary group cache

### DIFF
--- a/libfuse/Makefile
+++ b/libfuse/Makefile
@@ -56,7 +56,8 @@ SRC_CPP = \
 	lib/fuse_msgbuf.cpp \
 	lib/pin_threads.cpp \
 	lib/format.cpp \
-	lib/node.cpp
+	lib/node.cpp \
+	lib/maintenance_thread.cpp
 
 OBJS_C   = $(SRC_C:lib/%.c=build/%.o)
 OBJS_CPP = $(SRC_CPP:lib/%.cpp=build/%.o)

--- a/libfuse/include/fuse.h
+++ b/libfuse/include/fuse.h
@@ -688,8 +688,7 @@ int fuse_is_lib_option(const char *opt);
  */
 int fuse_main_real(int argc, char *argv[], const struct fuse_operations *op, size_t op_size);
 
-int  fuse_start_maintenance_thread(struct fuse *fuse);
-void fuse_stop_maintenance_thread(struct fuse *fuse);
+void fuse_populate_maintenance_thread(struct fuse *fuse);
 
 int  fuse_log_metrics_get(void);
 void fuse_log_metrics_set(int enabled);

--- a/libfuse/include/maintenance_thread.hpp
+++ b/libfuse/include/maintenance_thread.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+
+
+class MaintenanceThread
+{
+public:
+  static void setup();
+  static void stop();
+  static void push_job(const std::function<void(int)> &func);
+};

--- a/libfuse/lib/maintenance_thread.cpp
+++ b/libfuse/lib/maintenance_thread.cpp
@@ -1,0 +1,65 @@
+#include "maintenance_thread.hpp"
+
+#include "fmt/core.h"
+
+#include <cassert>
+#include <mutex>
+#include <vector>
+
+#include <pthread.h>
+#include <unistd.h>
+
+
+pthread_t g_thread;
+std::vector<std::function<void(int)>> g_funcs;
+std::mutex g_mutex;
+
+static
+void*
+_thread_loop(void *)
+{
+  int count;
+
+  pthread_setname_np(pthread_self(),"fuse.maint");
+
+  count = 0;
+  while(true)
+    {
+      pthread_setcancelstate(PTHREAD_CANCEL_DISABLE,NULL);
+      {
+        std::lock_guard<std::mutex> lg(g_mutex);
+        for(auto &func : g_funcs)
+          func(count);
+      }
+      pthread_setcancelstate(PTHREAD_CANCEL_ENABLE,NULL);
+
+      count++;
+      ::sleep(60);
+    }
+
+  return NULL;
+}
+
+void
+MaintenanceThread::setup()
+{
+  int rv;
+
+  rv = pthread_create(&g_thread,NULL,_thread_loop,NULL);
+  assert((rv == 0) && "pthread_create failed");
+}
+
+void
+MaintenanceThread::push_job(const std::function<void(int)> &func_)
+{
+  std::lock_guard<std::mutex> lg(g_mutex);
+
+  g_funcs.emplace_back(func_);
+}
+
+void
+MaintenanceThread::stop()
+{
+  pthread_cancel(g_thread);
+  pthread_join(g_thread,NULL);
+}

--- a/mkdocs/docs/config/options.md
+++ b/mkdocs/docs/config/options.md
@@ -8,7 +8,7 @@ background](../intro_to_filesystems.md) in such things is recommended
 for more advanced configurations.
 
 These option names and values are the same regardless of whether you
-use them with the `mergerfs` commandline program, in fstab, or in a
+use them with the `mergerfs` command line program, in fstab, or in a
 config file.
 
 
@@ -204,6 +204,12 @@ config file.
 * **[passthrough](passthrough.md)**: Enable [FUSE IO
   passthrough](https://kernelnewbies.org/Linux_6.9#Faster_FUSE_I.2FO)
   if available. (default: off)
+* **gid-cache-expire-timeout**: Number of seconds till supplemental
+  group data is refreshed in the [GID
+  cache](../known_issues_bugs.md#supplemental-user-groups). (default:
+  3600)
+* **gid-cache-remove-timeout**: Number of seconds to wait till cached
+  data is removed due to lack of usage. (default: 43200)
 
 **NOTE:** Options are evaluated in the order listed so if the options
 are **func.rmdir=rand,category.action=ff** the **action** category

--- a/mkdocs/docs/known_issues_bugs.md
+++ b/mkdocs/docs/known_issues_bugs.md
@@ -4,25 +4,26 @@
 
 ### Supplemental user groups
 
+#### Supplemental group caching
+
 Due to the overhead of
 [getgroups/setgroups](http://linux.die.net/man/2/setgroups) mergerfs
-utilizes a cache. This cache is opportunistic and per thread. Each
-thread will query the supplemental groups for a user when that
-particular thread needs to change credentials and will keep that data
-for the lifetime of the thread. This means that if a user is added to
-a group it may not be picked up without the restart of
-mergerfs. In the future this may be improved to allow a periodic or
-manual clearing of the cache.
+utilizes a cache. As necessary the supplemental group information will
+be queried and cached. That cached list of groups will be used to set
+the supplement groups as necessary. Due to the high cost of querying
+the group list the default expiry for said data is 1 hour and after 12
+hours of no usage will be removed from the cache all together.
+
+#### Host vs Container identity
 
 While not a bug some users have found when using containers that
 supplemental groups defined inside the container don't work as
 expected. Since mergerfs lives outside the container it is querying
-the host's group database. Effectively containers have their own user
-and group definitions unless setup otherwise just as different systems
-would.
+the host's group database. Containers have their own user and group
+definitions unless setup otherwise just as different systems would.
 
 Users should mount in the host group file into the containers or use a
-standard shared user & groups technology like NIS or LDAP.
+standard shared user and groups technology like NIS or LDAP.
 
 
 ### directory mtime is not being updated

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -106,6 +106,8 @@ Config::Config()
     fsname(),
     func(),
     fuse_msg_size("1M"),
+    gid_cache_expire_timeout(60 * 60),
+    gid_cache_remove_timeout(60 * 60 * 12),
     ignorepponrename(false),
     inodecalc("hybrid-hash"),
     lazy_umount_mountpoint(false),
@@ -184,6 +186,8 @@ Config::Config()
   _map["func.unlink"]            = &func.unlink;
   _map["func.utimens"]           = &func.utimens;
   _map["fuse_msg_size"]          = &fuse_msg_size;
+  _map["gid-cache-expire-timeout"] = &gid_cache_expire_timeout;
+  _map["gid-cache-remove-timeout"] = &gid_cache_remove_timeout;
   _map["handle-killpriv"]        = &handle_killpriv;
   _map["handle-killpriv-v2"]     = &handle_killpriv_v2;
   _map["ignorepponrename"]       = &ignorepponrename;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -21,6 +21,7 @@
 #include "config_cachefiles.hpp"
 #include "config_flushonclose.hpp"
 #include "config_follow_symlinks.hpp"
+#include "config_gidcache.hpp"
 #include "config_inodecalc.hpp"
 #include "config_link_exdev.hpp"
 #include "config_log_metrics.hpp"
@@ -130,6 +131,8 @@ public:
   ConfigSTR      fsname;
   Funcs          func;
   ConfigPageSize fuse_msg_size;
+  GIDCacheExpireTimeout gid_cache_expire_timeout;
+  GIDCacheRemoveTimeout gid_cache_remove_timeout;
   ConfigBOOL     handle_killpriv = true;
   ConfigBOOL     handle_killpriv_v2 = true;
   ConfigBOOL     ignorepponrename;

--- a/src/config_gidcache.cpp
+++ b/src/config_gidcache.cpp
@@ -1,0 +1,65 @@
+#include "config_gidcache.hpp"
+
+#include "gidcache.hpp"
+
+#include "to_string.hpp"
+#include "from_string.hpp"
+
+
+GIDCacheExpireTimeout::GIDCacheExpireTimeout(const int i_)
+{
+  GIDCache::expire_timeout = i_;
+}
+
+GIDCacheExpireTimeout::GIDCacheExpireTimeout(const std::string &s_)
+{
+  from_string(s_);
+}
+
+std::string
+GIDCacheExpireTimeout::to_string(void) const
+{
+  return str::to(GIDCache::expire_timeout);
+}
+
+int
+GIDCacheExpireTimeout::from_string(const std::string &s_)
+{
+  int rv;
+
+  rv = str::from(s_,&GIDCache::expire_timeout);
+  if(rv < 0)
+    return rv;
+
+  return 0;
+}
+
+
+GIDCacheRemoveTimeout::GIDCacheRemoveTimeout(const int i_)
+{
+  GIDCache::remove_timeout = i_;
+}
+
+
+GIDCacheRemoveTimeout::GIDCacheRemoveTimeout(const std::string &s_)
+{
+  from_string(s_);
+}
+
+std::string
+GIDCacheRemoveTimeout::to_string(void) const
+{
+  return str::to(GIDCache::remove_timeout);
+}
+
+int
+GIDCacheRemoveTimeout::from_string(const std::string &s_)
+{
+  int rv;
+
+  rv = str::from(s_,&GIDCache::remove_timeout);
+  if(rv < 0)
+    return rv;
+
+  return 0;
+}

--- a/src/config_gidcache.hpp
+++ b/src/config_gidcache.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "tofrom_string.hpp"
+
+class GIDCacheExpireTimeout : public ToFromString
+{
+public:
+  GIDCacheExpireTimeout(const int i = 60 * 60);
+  GIDCacheExpireTimeout(const std::string &);
+
+public:
+  std::string to_string(void) const final;
+  int from_string(const std::string &) final;
+};
+
+class GIDCacheRemoveTimeout : public ToFromString
+{
+public:
+  GIDCacheRemoveTimeout(const int = 60 * 60 * 12);
+  GIDCacheRemoveTimeout(const std::string &);
+
+public:
+  std::string to_string(void) const final;
+  int from_string(const std::string &) final;
+};

--- a/src/fuse_ioctl.cpp
+++ b/src/fuse_ioctl.cpp
@@ -336,7 +336,7 @@ namespace l
         fuse_invalidate_all_nodes();
         return 0;
       case IOCTL_INVALIDATE_GID_CACHE:
-        GIDCache::invalidate_all_caches();
+        GIDCache::invalidate_all();
         break;
       }
 

--- a/src/ugid.cpp
+++ b/src/ugid.cpp
@@ -28,8 +28,6 @@ namespace ugid
   initgroups(const uid_t uid_,
              const gid_t gid_)
   {
-    static thread_local GIDCache cache;
-
-    cache.initgroups(uid_,gid_);
+    GIDCache::initgroups(uid_,gid_);
   }
 }


### PR DESCRIPTION
* Use concurrent_flat_map to build a global cache rather than per thread.
* Create global maintanence thread manager for clearing unused cache entries.