### PR TITLE
Allow empty lines in config ini files

### DIFF
--- a/mkdocs/docs/quickstart.md
+++ b/mkdocs/docs/quickstart.md
@@ -95,6 +95,7 @@ cache.files=off
 category.create=pfrd
 func.getattr=newest
 dropcacheonclose=false
+# comments and empty lines are supported
 ```
 
 #### /etc/mergerfs/branches/media/

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -381,7 +381,7 @@ Config::from_stream(std::istream &istrm_,
   while(std::getline(istrm_,line,'\n'))
     {
       line = str::trim(line);
-      if(!line.empty() && (line[0] == '#'))
+      if(line.empty() || (line[0] == '#'))
         continue;
 
       str::splitkv(line,'=',&key,&val);


### PR DESCRIPTION
This changes will allow to have empty lines in `.ini` configs.
It also show that comments are supported in the docs.