### PR TITLE
add mkdocs post-deployment test

### DIFF
--- a/.github/scripts/mkdocs_check.py
+++ b/.github/scripts/mkdocs_check.py
@@ -1,0 +1,34 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import requests
+
+# Set up the Chrome WebDriver
+options = webdriver.ChromeOptions()
+options.add_argument('--headless')
+options.add_argument('--no-sandbox')
+options.add_argument('--disable-dev-shm-usage')
+
+
+url = 'https://trapexit.github.io/mergerfs'
+print(f"*** Checking {url} ***")
+
+driver = webdriver.Chrome(options=options)
+driver.get(url)
+request = requests.get(url)
+print(f"INFO: Page returned HTTP {request.status_code}")
+request.raise_for_status()
+
+# Wait for the page to load body
+WebDriverWait(driver, 10).until(
+    EC.presence_of_element_located((By.TAG_NAME, "body"))
+)
+
+# Get the fully rendered page source
+page_source = driver.page_source
+driver.quit()
+
+if "<h1>404 - Not found</h1>" in page_source:
+    print("ERROR: Page contains mkdocs error: '404 - Not found'")
+    exit(1)

--- a/.github/scripts/mkdocs_check.py
+++ b/.github/scripts/mkdocs_check.py
@@ -20,7 +20,7 @@ request = requests.get(url)
 print(f"INFO: Page returned HTTP {request.status_code}")
 request.raise_for_status()
 
-# Wait for the page to load body
+# Wait for the page to load <body> element
 WebDriverWait(driver, 10).until(
     EC.presence_of_element_located((By.TAG_NAME, "body"))
 )

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -47,3 +47,19 @@ jobs:
             #git checkout gh-pages
             #git push -f origin gh-pages
           fi
+  check:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: pip install selenium requests
+      - name: Run mkdocs_check.py
+        run: python .github/scripts/mkdocs_check.py


### PR DESCRIPTION
This PR relates to https://github.com/trapexit/mergerfs/issues/1526 where the mkdocs site may return an http 200 code but there is an error with the mkdocs site itself.

This post deployment end-to-end test adds a very simple scraper that checks the docs site is up and that the mkdocs error '404 - not found' is not present on the rendered page.

Tested as GH action here: https://github.com/oregonpillow/mergerfs/actions/runs/17895050741/job/50880562985