### PR TITLE
Fix dirent64::namelen calculation

### DIFF
--- a/libfuse/include/fs_dirent64.hpp
+++ b/libfuse/include/fs_dirent64.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 namespace fs
 {
@@ -15,9 +16,10 @@ namespace fs
     char     name[];
 
   public:
-    int namelen() const
+    size_t
+    namelen() const
     {
-      return (reclen - offsetof(dirent64,name));
+      return ::strlen(name);
     }
   };
 }


### PR DESCRIPTION
Worked fine on my machine where padding seemed to be all zeroed out but that doesn't appear to be the case elsewhere.

Could try
https://codeberg.org/jbruchon/libjodycode/src/branch/master/dir.c#L92-L110 but needs to be tested.