### PR TITLE
Make allow-idmap optional (default: false)

### DIFF
--- a/libfuse/lib/fuse_lowlevel.cpp
+++ b/libfuse/lib/fuse_lowlevel.cpp
@@ -1931,6 +1931,15 @@ fuse_send_enomem(struct fuse_ll   *f_,
 }
 
 static
+void
+fuse_send_einval(struct fuse_ll   *f_,
+                 struct fuse_chan *ch_,
+                 const uint64_t    unique_id_)
+{
+  fuse_send_errno(f_,ch_,EINVAL,unique_id_);
+}
+
+static
 int
 fuse_ll_buf_receive_read(struct fuse_session *se_,
                          fuse_msgbuf_t       *msgbuf_)
@@ -1960,6 +1969,9 @@ fuse_ll_buf_process_read(struct fuse_session *se_,
   struct fuse_in_header *in;
 
   in = (struct fuse_in_header*)msgbuf_->mem;
+
+  if((in->uid == FUSE_INVALID_UIDGID) || (in->gid == FUSE_INVALID_UIDGID))
+    return fuse_send_einval(se_->f,se_->ch,in->unique);
 
   req = fuse_ll_alloc_req(se_->f);
   if(req == NULL)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -53,6 +53,7 @@ namespace l
   bool
   readonly(const std::string &s_)
   {
+    IFERT("allow-idmap");
     IFERT("async_read");
     IFERT("branches-mount-timeout");
     IFERT("branches-mount-timeout-fail");
@@ -81,7 +82,8 @@ namespace l
 }
 
 Config::Config()
-  : async_read(true),
+  : allow_idmap(false),
+    async_read(true),
     auto_cache(false),
     minfreespace(MINFREESPACE_DEFAULT),
     branches(minfreespace),
@@ -140,6 +142,7 @@ Config::Config()
     xattr(XAttr::ENUM::PASSTHROUGH),
     _initialized(false)
 {
+  _map["allow-idmap"]            = &allow_idmap;
   _map["async_read"]             = &async_read;
   _map["auto_cache"]             = &auto_cache;
   _map["branches"]               = &branches;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -83,6 +83,7 @@ public:
   Config& operator=(const Config&);
 
 public:
+  ConfigBOOL     allow_idmap;
   ConfigBOOL     async_read;
   ConfigBOOL     auto_cache;
   ConfigUINT64   minfreespace;

--- a/src/fuse_init.cpp
+++ b/src/fuse_init.cpp
@@ -206,7 +206,7 @@ FUSE::init(fuse_conn_info *conn_)
   ::_want_if_capable(conn_,FUSE_CAP_POSIX_ACL,&cfg.posix_acl);
   ::_want_if_capable(conn_,FUSE_CAP_READDIR_PLUS,&cfg.readdirplus);
   ::_want_if_capable(conn_,FUSE_CAP_WRITEBACK_CACHE,&cfg.writeback_cache);
-  ::_want_if_capable(conn_,FUSE_CAP_ALLOW_IDMAP);
+  ::_want_if_capable(conn_,FUSE_CAP_ALLOW_IDMAP,&cfg.allow_idmap);
   //    ::_want_if_capable(conn_,FUSE_CAP_READDIR_PLUS_AUTO);
   ::_want_if_capable_max_pages(conn_,cfg);
   conn_->want &= ~FUSE_CAP_POSIX_LOCKS;

--- a/src/gidcache.cpp
+++ b/src/gidcache.cpp
@@ -53,6 +53,9 @@ inline
 int
 _setgroups(const std::vector<gid_t> gids_)
 {
+  if(gids_.empty())
+    return 0;
+
 #if defined __linux__ and UGID_USE_RWLOCK == 0
 # if defined SYS_setgroups32
   return ::syscall(SYS_setgroups32,gids_.size(),gids_.data());
@@ -93,7 +96,7 @@ _getgroups(const uid_t         uid_,
 
  error:
   gids_.clear();
-  gids_.push_back(gid_);
+  //gids_.push_back(gid_);
 }
 
 

--- a/src/ugid_linux.hpp
+++ b/src/ugid_linux.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <assert.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -62,6 +63,9 @@ namespace ugid
     Set(const uid_t newuid_,
         const gid_t newgid_)
     {
+      assert((int)newuid_ != -1);
+      assert((int)newgid_ != -1);
+
       if(!initialized)
         {
           currentuid  = GETEUID();
@@ -81,7 +85,7 @@ namespace ugid
       if(newgid_)
         {
           SETREGID(-1,newgid_);
-          initgroups(newuid_,newgid_);
+          ugid::initgroups(newuid_,newgid_);
         }
 
       if(newuid_)


### PR DESCRIPTION
This is just to correct default behavior for now. More investigation is necessary to properly support idmapping.