### PR TITLE
Fix manpage links for 2.41.0-rc3

### DIFF
--- a/man/mergerfs.1
+++ b/man/mergerfs.1
@@ -12,16 +12,16 @@ is a FUSE-based union filesystem geared towards simplifying storage and manageme
 and
 .BR aufs .
 .SH QUICKSTART
-.UR https://trapexit.github.io/mergerfs/quickstart
-.LI https://trapexit.github.io/mergerfs/quickstart
+.UR https://trapexit.github.io/mergerfs/latest/quickstart
+.LI https://trapexit.github.io/mergerfs/latest/quickstart
 .UE
 .SH DOCUMENTATION
 .UR https://trapexit.github.io/mergerfs
 .LI https://trapexit.github.io/mergerfs
 .UE
 .SH SUPPORT
-.UR https://trapexit.github.io/mergerfs/support
-.LI https://trapexit.github.io/mergerfs/support
+.UR https://trapexit.github.io/mergerfs/latest/support
+.LI https://trapexit.github.io/mergerfs/latest/support
 .UE
 .SH FEATURES
 .IP \[bu] 2
@@ -74,8 +74,8 @@ When a file or directory is created, a policy is first run to determine which br
 For functions which change attributes or remove the file, the behavior may be applied to all instances found.
 
 Read more about policies here:
-.UR https://trapexit.github.io/mergerfs/config/functions_categories_and_policies
-.LI https://trapexit.github.io/mergerfs/config/functions_categories_and_policies
+.UR https://trapexit.github.io/mergerfs/latest/config/functions_categories_policies
+.LI https://trapexit.github.io/mergerfs/latest/config/functions_categories_policies
 .UE
 .SH VISUALIZATION
 .nf


### PR DESCRIPTION
The links in the mergerfs man page currently don't work..