### PR TITLE
tools/preload: include correct extended attribute headers on FreeBSD

### DIFF
--- a/tools/preload.c
+++ b/tools/preload.c
@@ -33,7 +33,11 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef __FreeBSD__
+#include <sys/extattr.h>
+#else
 #include <sys/xattr.h>
+#endif
 #include <unistd.h>
 
 typedef char IOCTL_BUF[4096];


### PR DESCRIPTION
Add conditional includes for extended attribute support. FreeBSD uses <sys/extattr.h> instead of <sys/xattr.h>, which prevents the preload module from building. This update selects the proper header based on the target platform and fixes the build failure on FreeBSD.