### PR TITLE
libfuse: fix narrowing conversion of nsec fields on i386

### DIFF
--- a/libfuse/lib/fuse.cpp
+++ b/libfuse/lib/fuse.cpp
@@ -1636,12 +1636,12 @@ fuse_lib_setattr(fuse_req_t            *req_,
           if(arg->valid & FATTR_ATIME_NOW)
             tv[0].tv_nsec = UTIME_NOW;
           else if(arg->valid & FATTR_ATIME)
-            tv[0] = (struct timespec){ static_cast<time_t>(arg->atime), arg->atimensec };
+            tv[0] = (struct timespec){ static_cast<time_t>(arg->atime), static_cast<long>(arg->atimensec) };
 
           if(arg->valid & FATTR_MTIME_NOW)
             tv[1].tv_nsec = UTIME_NOW;
           else if(arg->valid & FATTR_MTIME)
-            tv[1] = (struct timespec){ static_cast<time_t>(arg->mtime), arg->mtimensec };
+            tv[1] = (struct timespec){ static_cast<time_t>(arg->mtime), static_cast<long>(arg->mtimensec) };
 
           err = ((fusepath != NULL) ?
                  f.ops.utimens(&req_->ctx,&fusepath[1],tv) :


### PR DESCRIPTION
This patch fixes a build failure on 32 bit systems (for example FreeBSD i386 with clang 19) where clang rejects the initialization of struct timespec using a uint32_t nanosecond value inside a braced initializer.

On ILP32 platforms tv_nsec is a signed long. Assigning a uint32_t in a brace initializer is treated as a narrowing conversion under C++17 even though the actual nsec values are within the valid range. This leads to errors like:

  non-constant-expression cannot be narrowed from type 'uint32_t' to 'long'

The fix is to add an explicit static_cast<long>() for the nanosecond field in the two affected initializers. This makes the conversion explicit and restores portability across 32 bit and 64 bit systems.

Tested on:
* FreeBSD i386 13.5 (clang 19)
* FreeBSD amd64 14.3 (clang 19)

No functional behavior changes.