### PR TITLE
Fix vendored fmt build failure with newer Clang/libc++

### DIFF
--- a/libfuse/include/fmt/format.h
+++ b/libfuse/include/fmt/format.h
@@ -42,6 +42,7 @@
 
 #ifndef FMT_MODULE
 #  include <cmath>    // std::signbit
+#  include <cstdlib>  // std::malloc, std::free
 #  include <cstddef>  // std::byte
 #  include <cstdint>  // uint32_t
 #  include <cstring>  // std::memcpy

--- a/libfuse/lib/fuse.cpp
+++ b/libfuse/lib/fuse.cpp
@@ -1636,12 +1636,12 @@ fuse_lib_setattr(fuse_req_t            *req_,
           if(arg->valid & FATTR_ATIME_NOW)
             tv[0].tv_nsec = UTIME_NOW;
           else if(arg->valid & FATTR_ATIME)
-            tv[0] = (struct timespec){ static_cast<time_t>(arg->atime), arg->atimensec };
+            tv[0] = (struct timespec){ static_cast<time_t>(arg->atime), static_cast<long>(arg->atimensec) };
 
           if(arg->valid & FATTR_MTIME_NOW)
             tv[1].tv_nsec = UTIME_NOW;
           else if(arg->valid & FATTR_MTIME)
-            tv[1] = (struct timespec){ static_cast<time_t>(arg->mtime), arg->mtimensec };
+            tv[1] = (struct timespec){ static_cast<time_t>(arg->mtime), static_cast<long>(arg->mtimensec) };
 
           err = ((fusepath != NULL) ?
                  f.ops.utimens(&req_->ctx,&fusepath[1],tv) :


### PR DESCRIPTION
Recent FreeBSD -CURRENT builds fail because the vendored fmt header uses malloc/free without including the appropriate declarations.

Add to the existing non-module include block in libfuse/include/fmt/format.h.

This keeps the include ordering consistent with the surrounding code and matches the approach used upstream in fmt.

Tested successfully on:

FreeBSD 15.0-RELEASE
FreeBSD 14.3-RELEASE-p6
FreeBSD 13.5-RELEASE-p7

Issue reproduced on recent FreeBSD -CURRENT with newer Clang/libc++ toolchains.