### PR TITLE
C++20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ MKDIR     ?= mkdir
 MKTEMP    ?= mktemp
 MV        ?= mv
 RM 	  ?= rm
+RPMBUILD  ?= rpmbuild
+RPMBUILD_FLAGS ?=
 SED       ?= sed
 STRIP     ?= strip
 TAR 	  ?= tar
@@ -343,7 +345,7 @@ rpm: tarball
 	$(SED) 's/__VERSION__/$(VERSION)/g' mergerfs.spec > \
 		rpmbuild/SOURCES/mergerfs.spec
 	cp -ar mergerfs-$(VERSION).tar.gz rpmbuild/SOURCES
-	rpmbuild -ba rpmbuild/SOURCES/mergerfs.spec \
+	$(RPMBUILD) $(RPMBUILD_FLAGS) -ba rpmbuild/SOURCES/mergerfs.spec \
 		--define "_topdir $(CURDIR)/rpmbuild"
 
 .PHONY: install-build-pkgs

--- a/buildtools/build-mergerfs
+++ b/buildtools/build-mergerfs
@@ -5,6 +5,15 @@ if [ -e /tmp/build-env ]; then
     . /tmp/build-env
 fi
 
+rpmbuild_flags()
+{
+    case "$(command -v "${CXX:-g++}")" in
+        /opt/rh/*)
+            printf '%s' '--undefine _annotated_build'
+            ;;
+    esac
+}
+
 if [ $# -ne 2 ]; then
     echo "usage: $0 <branch> <git_repo>"
     echo "argv: $@"
@@ -32,9 +41,9 @@ mkdir "/build"
 if [ -e /usr/bin/apt-get ]; then
     make deb
 elif [ -e /usr/bin/dnf ]; then
-    make rpm
+    make RPMBUILD_FLAGS="$(rpmbuild_flags)" rpm
 elif [ -e /usr/bin/yum ]; then
-    make rpm
+    make RPMBUILD_FLAGS="$(rpmbuild_flags)" rpm
 elif [ -e /sbin/apk ]; then
     echo "NOT YET SUPPORTED"
     exit 1


### PR DESCRIPTION
Important changes:
- Add Makefile RPMBUILD and RPMBUILD_FLAGS overrides for the rpm target.
- Detect /opt/rh GCC toolsets before RPM packaging.
- Pass --undefine _annotated_build to avoid Rocky 8 annobin plugin failures.